### PR TITLE
Add CORS Middleware

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
       - id: linting
         name: linting
         description: Run isort black flake8 pylint
-        entry: bash -c "make format"
+        entry: bash -c "source .venv/bin/activate && make format"
         language: python
         pass_filenames: false
         always_run: true
@@ -13,7 +13,7 @@ repos:
       - id: small-tests
         name: small-tests
         description: Small-sized tests
-        entry: bash -c "make test-small"
+        entry: bash -c "source .venv/bin/activate && make test-small"
         language: python
         pass_filenames: false
         always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
       - id: linting
         name: linting
         description: Run isort black flake8 pylint
-        entry: bash -c "source .venv/bin/activate && make format"
+        entry: bash -c "make format"
         language: python
         pass_filenames: false
         always_run: true
@@ -13,7 +13,7 @@ repos:
       - id: small-tests
         name: small-tests
         description: Small-sized tests
-        entry: bash -c "source .venv/bin/activate && export PYTHONPATH=./src && make test-small"
+        entry: bash -c "make test-small"
         language: python
         pass_filenames: false
         always_run: true

--- a/src/chronicler_backend/main.py
+++ b/src/chronicler_backend/main.py
@@ -1,5 +1,6 @@
 import strawberry
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from strawberry.fastapi import GraphQLRouter
 
 from chronicler_backend.query import MyQuery
@@ -8,4 +9,13 @@ schema = strawberry.Schema(query=MyQuery)
 graphql_app = GraphQLRouter(schema)
 
 app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000"],  # Allow only frontend URL
+    allow_credentials=True,
+    allow_methods=["GET", "POST"],  # Specify allowed methods
+    allow_headers=["Content-Type", "Authorization"],  # Specify allowed headers
+)
+
 app.include_router(graphql_app, prefix="/graphql")

--- a/src/chronicler_backend/main.py
+++ b/src/chronicler_backend/main.py
@@ -12,10 +12,10 @@ app = FastAPI()
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],  # Allow only frontend URL
+    allow_origins=["http://localhost:3000"],
     allow_credentials=True,
-    allow_methods=["GET", "POST"],  # Specify allowed methods
-    allow_headers=["Content-Type", "Authorization"],  # Specify allowed headers
+    allow_methods=["GET", "POST"],
+    allow_headers=["Content-Type", "Authorization"],
 )
 
 app.include_router(graphql_app, prefix="/graphql")


### PR DESCRIPTION
# Changes
- Adds [CORS Middleware](https://fastapi.tiangolo.com/tutorial/cors/) so that both FE and BE can be hosted on the same machine for local development. Assumes FE will be on `http://localhost:3000`
- Cleans up pre-commit command syntax