### PR TITLE
Add sentence transformer for vector embeddings

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,66 @@
+# Python cache files
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Logs
+logs/
+*.log
+
+# Docker specific
+.dockerignore
+.git
+.github
+.gitignore
+
+# # Model weights
+# model_weights/
+
+# VS Code
+.vscode/
+
+# macOS
+.DS_Store
+
+# Docker volumes
+neo4j_data/
+api_packages/

--- a/.env.example
+++ b/.env.example
@@ -1,19 +1,22 @@
-
 # Application Environment
 # THIS FILE IS A TEMPLATE. COPY IT TO .env AND FILL IN YOUR VALUES.
 # DO NOT COMMIT YOUR .env FILE TO VERSION CONTROL.
-ENV=development  # development, testing, production
+
+# development, testing, production
+ENV=development
 
 # Neo4j Development Configuration
 NEO4J_URI=bolt://neo4j:7687
-NEO4J_USER=neo4j # Must be this for admin
-NEO4J_PASSWORD=<YOUR-PASSWORD> 
+# Must be this for admin
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=<YOUR-PASSWORD>
 NEO4J_PORT=7474
 NEO4J_BOLT_PORT=7687
 
 # Neo4j Test Configuration
 NEO4J_TEST_URI=bolt://neo4j-test:7687
-NEO4J_TEST_USER=neo4j # Must be this for admin
+# Must be this for admin
+NEO4J_TEST_USER=neo4j
 NEO4J_TEST_PASSWORD=<YOUR-TEST-PASSWORD>
 NEO4J_TEST_PORT=7475
 NEO4J_TEST_BOLT_PORT=7688
@@ -26,10 +29,14 @@ FASTAPI_DEBUG=true
 FASTAPI_WORKERS=1
 
 # Logging
-LOG_LEVEL=DEBUG  # DEBUG, INFO, WARNING, ERROR, CRITICAL
+# DEBUG, INFO, WARNING, ERROR, CRITICAL
+LOG_LEVEL=DEBUG
 
 # CORS Settings
-CORS_ALLOW_ORIGINS=*  # Comma-separated list of origins or * for all
+# Comma-separated list of origins or * for all
+CORS_ALLOW_ORIGINS=*
 CORS_ALLOW_CREDENTIALS=true
-CORS_ALLOW_METHODS=*  # Comma-separated list of HTTP methods or * for all
-CORS_ALLOW_HEADERS=*  # Comma-separated list of HTTP headers or * for all
+# Comma-separated list of HTTP methods or * for all
+CORS_ALLOW_METHODS=*
+# Comma-separated list of HTTP headers or * for all
+CORS_ALLOW_HEADERS=*

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E266, D203, H306, W503, E712, W605
+ignore = E266, D203, H306, W503, E712, W605, E251, E202
 exclude = .git,.venv,notebooks
 max-complexity = 10
 max_line_length = 100

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ COPY . .
 ARG ENV=production
 ENV ENV=${ENV}
 ENV PYTHONPATH="/app:/app/src:${PYTHONPATH}"
-ENV MODEL_DIR="/app/model_weights"
+ARG MODEL_DIR=/app/model_weights
+ENV MODEL_DIR=${MODEL_DIR}
 
 RUN echo "Building for environment: ${ENV}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,8 +69,11 @@ RUN mkdir -p ${MODEL_DIR}
 RUN chmod +x /app/scripts/entrypoint.sh
 
 # Reduce image size by cleaning up
-RUN find /app/.venv -name "*.pyc" -delete && \
-    find /app/.venv -name "__pycache__" -delete
+RUN find /app -name "*.pyc" -delete && \
+    find /app -name "__pycache__" -delete && \
+    find /app/.venv -name "*.dist-info" -type d -exec rm -rf {} \; 2>/dev/null || true && \
+    find /app/.venv -name "tests" -type d -exec rm -rf {} \; 2>/dev/null || true && \
+    find /app/.venv -name "doc" -type d -exec rm -rf {} \; 2>/dev/null || true
 
 # Expose port
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,41 +3,74 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
 
 WORKDIR /app
 
+# Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy pyproject.toml and .python-version first to leverage Docker caching
-COPY pyproject.toml .python-version ./
+# Copy ALL project metadata files first
+COPY pyproject.toml .python-version README.md ./
+# If you have any other metadata files (like LICENSE, MANIFEST.in) add them here
 
-# Copy source code
+# Create src directory structure (if your project needs it)
+RUN mkdir -p src
+
+# Create virtual environment
+RUN uv venv /app/.venv && \
+    . /app/.venv/bin/activate
+
+# Copy application code
 COPY . .
 
-# Environment variables
+# Now install dependencies after all files are copied
+ARG ENV=production
+RUN . /app/.venv/bin/activate && \
+    if [ "${ENV}" = "development" ] || [ "${ENV}" = "local" ]; then \
+    echo "Installing development dependencies" && \
+    uv pip install --no-cache-dir .[dev,test]; \
+    else \
+    echo "Installing production dependencies" && \
+    uv pip install --no-cache-dir .; \
+    fi
+
+# Stage 2: Final image
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+
+WORKDIR /app
+
+# Install runtime dependencies only
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set environment variables
 ARG ENV=production
 ENV ENV=${ENV}
 ENV PYTHONPATH="/app:/app/src:${PYTHONPATH}"
 ARG MODEL_DIR=/app/model_weights
 ENV MODEL_DIR=${MODEL_DIR}
+ENV PATH="/app/.venv/bin:${PATH}"
 
-RUN echo "Building for environment: [${ENV}]"
+# Copy virtual environment from builder stage
+COPY --from=builder /app/.venv /app/.venv
 
-RUN uv venv /app/.venv && \
-    . /app/.venv/bin/activate && \
-    if [ "${ENV}" = "development" ] || [ "${ENV}" = "local" ]; then \
-    echo "Installing development dependencies" && \
-    uv pip install --no-cache-dir -e .[dev,test]; \
-    else \
-    echo "Installing production dependencies" && \
-    uv pip install --no-cache-dir -e .; \
-    fi
+# Copy only necessary files from builder stage
+COPY --from=builder /app/src /app/src
+COPY --from=builder /app/scripts /app/scripts
+COPY --from=builder /app/pyproject.toml /app/
+COPY --from=builder /app/.python-version /app/
+COPY --from=builder /app/README.md /app/
 
 # Create MODEL_DIR if it doesn't exist
 RUN mkdir -p ${MODEL_DIR}
 
 # Make entrypoint script executable
 RUN chmod +x /app/scripts/entrypoint.sh
+
+# Reduce image size by cleaning up
+RUN find /app/.venv -name "*.pyc" -delete && \
+    find /app/.venv -name "__pycache__" -delete
 
 # Expose port
 EXPOSE 8000
@@ -46,5 +79,5 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/health || exit 1
 
-# Use the entrypoint script instead of inline command
+# Use the entrypoint script
 ENTRYPOINT ["/app/scripts/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,14 +36,8 @@ RUN uv venv /app/.venv && \
 # Create MODEL_DIR if it doesn't exist
 RUN mkdir -p ${MODEL_DIR}
 
-# Download model
-RUN echo "Downloading model to ${MODEL_DIR}/quantized-model" && \
-    . /app/.venv/bin/activate && \
-    uv run scripts/download_model.py --output-dir ${MODEL_DIR}/quantized-model \
-    --verbose
-
-# Give permissions to the model directory
-RUN chmod -R 755 ${MODEL_DIR}
+# Make entrypoint script executable
+RUN chmod +x /app/scripts/entrypoint.sh
 
 # Expose port
 EXPOSE 8000
@@ -52,12 +46,5 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/health || exit 1
 
-# Command to run the application - conditionally use --reload
-CMD ["sh", "-c", ". /app/.venv/bin/activate && \
-    if [ \"${ENV}\" = \"development\" ] || [ \"${ENV}\" = \"local\" ]; then \
-    echo \"Starting in development mode with hot reload\"; \
-    uvicorn src.chronicler_backend.main:app --host 0.0.0.0 --port 8000 --reload; \
-    else \
-    echo \"Starting in production mode\"; \
-    uvicorn src.chronicler_backend.main:app --host 0.0.0.0 --port 8000; \
-    fi"]
+# Use the entrypoint script instead of inline command
+ENTRYPOINT ["/app/scripts/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,8 @@ RUN mkdir -p ${MODEL_DIR}
 # Download model
 RUN echo "Downloading model to ${MODEL_DIR}/quantized-model" && \
     . /app/.venv/bin/activate && \
-    uv run scripts/download_model.py --output-dir ${MODEL_DIR}/quantized-model --verbose && \
-    ls -la ${MODEL_DIR}/quantized-model
+    uv run scripts/download_model.py --output-dir ${MODEL_DIR}/quantized-model \
+    --verbose --force
 
 # Expose port
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# Stage 1: Builder
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS builder
 
 WORKDIR /app
@@ -10,35 +11,35 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Copy pyproject.toml and .python-version first to leverage Docker caching
 COPY pyproject.toml .python-version ./
 
-# Copy the entire src directory 
-COPY src/ ./src/
-COPY README.md ./
+# Copy source code
+COPY . .
+
+# Environment variables
+ARG ENV=production
+ENV ENV=${ENV}
+ENV PYTHONPATH="/app:/app/src:${PYTHONPATH}"
+ENV MODEL_DIR="/app/model_weights"
+
+RUN echo "Building for environment: ${ENV}"
 
 RUN uv venv /app/.venv && \
     . /app/.venv/bin/activate && \
-    uv pip install --no-cache-dir -e .[dev,test]
+    if [ "${ENV}" = "development" ] || [ "${ENV}" = "local" ]; then \
+    echo "Installing development dependencies" && \
+    uv pip install --no-cache-dir -e .[dev,test]; \
+    else \
+    echo "Installing production dependencies" && \
+    uv pip install --no-cache-dir -e .; \
+    fi
 
-# Final image
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS runtime
+# Create MODEL_DIR if it doesn't exist
+RUN mkdir -p ${MODEL_DIR}
 
-WORKDIR /app
-
-# Install runtime dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    wget \
-    curl \
-    git \
-    && rm -rf /var/lib/apt/lists/*
-
-# Copy virtual environment from builder
-COPY --from=builder /app/.venv /app/.venv
-
-# Make sure we use the virtualenv
-ENV PATH="/app/.venv/bin:$PATH"
-ENV PYTHONPATH="/app:$PYTHONPATH"
-
-# Copy source code
-COPY . .
+# Download model
+RUN echo "Downloading model to ${MODEL_DIR}/quantized-model" && \
+    . /app/.venv/bin/activate && \
+    uv run scripts/download_model.py --output-dir ${MODEL_DIR}/quantized-model --verbose && \
+    ls -la ${MODEL_DIR}/quantized-model
 
 # Expose port
 EXPOSE 8000
@@ -47,5 +48,12 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/health || exit 1
 
-# Command to run the application
-CMD ["uvicorn", "src.chronicler_backend.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+# Command to run the application - conditionally use --reload
+CMD ["sh", "-c", ". /app/.venv/bin/activate && \
+    if [ \"${ENV}\" = \"development\" ] || [ \"${ENV}\" = \"local\" ]; then \
+    echo \"Starting in development mode with hot reload\"; \
+    uvicorn src.chronicler_backend.main:app --host 0.0.0.0 --port 8000 --reload; \
+    else \
+    echo \"Starting in production mode\"; \
+    uvicorn src.chronicler_backend.main:app --host 0.0.0.0 --port 8000; \
+    fi"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ENV PYTHONPATH="/app:/app/src:${PYTHONPATH}"
 ARG MODEL_DIR=/app/model_weights
 ENV MODEL_DIR=${MODEL_DIR}
 
-RUN echo "Building for environment: ${ENV}"
+RUN echo "Building for environment: [${ENV}]"
 
 RUN uv venv /app/.venv && \
     . /app/.venv/bin/activate && \
@@ -40,7 +40,10 @@ RUN mkdir -p ${MODEL_DIR}
 RUN echo "Downloading model to ${MODEL_DIR}/quantized-model" && \
     . /app/.venv/bin/activate && \
     uv run scripts/download_model.py --output-dir ${MODEL_DIR}/quantized-model \
-    --verbose --force
+    --verbose
+
+# Give permissions to the model directory
+RUN chmod -R 755 ${MODEL_DIR}
 
 # Expose port
 EXPOSE 8000

--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,6 @@ docker-size: podman-check
 # +++++++ +++++++ +++++++
 define run_tests
 	@mkdir -p logs
-	export PYTHONPATH=${SOURCE_DIR} && \
 	$(DOCKER_CMD) exec -it chronicler-backend /bin/bash -c " \
 		uv run coverage run --data-file=/app/logs/.coverage --source=${SOURCE_DIR} --omit=\"*/tests/*\" \
 		-m pytest -rs -vv --log-level=${PYTEST_LOG_LEVEL} $1" \

--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ endef
 
 test-all: podman-check
 	@mkdir -p logs
-	clear && $(call run_tests,${TESTS_DIR},${PYTEST_COV_MIN})
+	$(call run_tests,${TESTS_DIR},${PYTEST_COV_MIN})
 
 test-small: podman-check
 	@mkdir -p logs

--- a/Makefile
+++ b/Makefile
@@ -276,10 +276,12 @@ endif
 # Model Management
 # ++++++++++++++++++++++++
 # Download and quantize the sentence transformer model locally
+# Usage: make download-model-local [force=true]
+# force=true will force the download even if the model already exists
 download-model-local:
 	@echo "Downloading and quantizing sentence transformer model locally..."
 	@mkdir -p $(MODEL_DIR) && \
-	uv run scripts/download_model.py --output-dir $(MODEL_PATH)
+	uv run scripts/download_model.py --output-dir $(MODEL_PATH) $(if $(filter true,$(force)),--force,)
 
 # Download and quantize the sentence transformer model within the Docker container
 download-model-docker: podman-check
@@ -293,6 +295,7 @@ download-model-docker: podman-check
 	else \
 		echo "No existing model found. Downloading and quantizing in container..."; \
 		MODEL_PATH_DOCKER=$$(echo $(MODEL_PATH) | sed 's|^\./|/app/|'); \
-		$(DOCKER_CMD) exec -it chronicler-backend bash -c "mkdir -p $$MODEL_PATH_DOCKER && MODEL_PATH=$$MODEL_PATH_DOCKER uv run /app/scripts/download_model.py"; \
+		$(DOCKER_CMD) exec -it chronicler-backend bash -c "mkdir -p $$MODEL_PATH_DOCKER \
+		&& MODEL_PATH=$$MODEL_PATH_DOCKER uv run /app/scripts/download_model.py"; \
 	fi
 	@echo "Model setup complete!"

--- a/Makefile
+++ b/Makefile
@@ -119,10 +119,10 @@ setup-local-dev:
 	uv pip install -e .[dev,test]
 	@echo "Installing pre-commit hooks..."
 	uv run pre-commit install
-	make download-model-local
 	@echo "Local development environment ready!"
 	@echo "Note: You'll still need Neo4j running for database operations"
 	@echo "Consider 'make neo4j-only' for just the Neo4j service if needed"
+	@echo "You also may need to download the model locally using 'make download-model-local'"
 
 # ++++++++++++++++++++++++
 # Docker Compose Commands

--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ docker-deep-clean: docker-down
 
 # Rebuild all services with Docker Compose
 docker-build: podman-check
-	$(COMPOSE_CMD) build
+	$(COMPOSE_CMD) --progress=plain build
 	@echo "All services rebuilt with Docker Compose"
 
 # Rebuild and restart all services

--- a/Makefile
+++ b/Makefile
@@ -213,13 +213,15 @@ neo4j-test-shell: podman-check
 	$(DOCKER_CMD) exec -it chronicler-neo4j-test cypher-shell \
 	-u $(NEO4J_TEST_USER) -p $(NEO4J_TEST_PASSWORD)
 
-# Check Python version in the container
-docker-python-version: podman-check
-	$(DOCKER_CMD) exec -it chronicler-backend python --version
+# Check Docker image sizes
+docker-size: podman-check
+	@echo "Checking Docker image sizes..."
+	@echo "--------------------------------"
+	@$(DOCKER_CMD) images --format "table {{.Repository}}\t{{.Tag}}\t{{.Size}}" | grep -E 'chronicler|REPOSITORY'
+	@echo "--------------------------------"
+	@echo "Total disk space used by Docker:"
+	@$(DOCKER_CMD) system df
 
-# Check UV version in the container
-docker-uv-version: podman-check
-	$(DOCKER_CMD) exec -it chronicler-backend uv --version
 
 # +++++++ +++++++ +++++++
 # Sized testing

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 .PHONY: clean docker-up docker-down docker-clean docker-deep-clean docker-build docker-logs docker-status \
 		docker-shell docker-test docker-test-small docker-test-medium docker-test-large \
 		format isort black flake8 pylint neo4j-shell neo4j-test-shell scripts-executable \
-		podman-check
+		podman-check download-model-local download-model-docker
 
 SOURCE_DIR=./src
 SOURCE_PATH=./src/chronicler-backend
+MODEL_DIR=./model_weights
+MODEL_PATH=./model_weights/quantized-model
 TESTS_DIR=./tests
 PYTEST_LOG_LEVEL=DEBUG
 PYTEST_COV_MIN=50
@@ -112,9 +114,12 @@ setup-dev: scripts-executable
 # ++++++++++++++++++++++++
 setup-local-dev:
 	@echo "Setting up local development environment..."
+	@echo "Creating virtual environment..."
 	uv venv
 	uv pip install -e .[dev,test]
+	@echo "Installing pre-commit hooks..."
 	uv run pre-commit install
+	make download-model-local
 	@echo "Local development environment ready!"
 	@echo "Note: You'll still need Neo4j running for database operations"
 	@echo "Consider 'make neo4j-only' for just the Neo4j service if needed"
@@ -266,3 +271,28 @@ ifndef TEST_CASE
 endif
 	@mkdir -p logs
 	$(call run_tests,$(TEST_PATH) -k "$(TEST_CASE)")
+
+# ++++++++++++++++++++++++
+# Model Management
+# ++++++++++++++++++++++++
+# Download and quantize the sentence transformer model locally
+download-model-local:
+	@echo "Downloading and quantizing sentence transformer model locally..."
+	@mkdir -p $(MODEL_DIR) && \
+	uv run scripts/download_model.py --output-dir $(MODEL_PATH)
+
+# Download and quantize the sentence transformer model within the Docker container
+download-model-docker: podman-check
+	@echo "Checking for existing model files..."
+	@if [ -d "$(MODEL_PATH)" ] && [ "$$(ls -A $(MODEL_PATH) 2>/dev/null)" ]; then \
+		echo "Found existing model files, copying to container..."; \
+		MODEL_PATH_DOCKER=$$(echo $(MODEL_PATH) | sed 's|^\./|/app/|'); \
+		$(DOCKER_CMD) exec -it chronicler-backend bash -c "mkdir -p $$MODEL_PATH_DOCKER"; \
+		$(DOCKER_CMD) cp $(MODEL_PATH)/. chronicler-backend:$$MODEL_PATH_DOCKER/; \
+		echo "Model files copied to container!"; \
+	else \
+		echo "No existing model found. Downloading and quantizing in container..."; \
+		MODEL_PATH_DOCKER=$$(echo $(MODEL_PATH) | sed 's|^\./|/app/|'); \
+		$(DOCKER_CMD) exec -it chronicler-backend bash -c "mkdir -p $$MODEL_PATH_DOCKER && MODEL_PATH=$$MODEL_PATH_DOCKER uv run /app/scripts/download_model.py"; \
+	fi
+	@echo "Model setup complete!"

--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,7 @@ docker-uv-version: podman-check
 # Sized testing
 # +++++++ +++++++ +++++++
 define run_tests
+	@mkdir -p logs
 	export PYTHONPATH=${SOURCE_DIR} && \
 	$(DOCKER_CMD) exec -it chronicler-backend /bin/bash -c " \
 		uv run coverage run --data-file=/app/logs/.coverage --source=${SOURCE_DIR} --omit=\"*/tests/*\" \
@@ -240,19 +241,15 @@ define run_tests
 endef
 
 test-all: podman-check
-	@mkdir -p logs
 	$(call run_tests,${TESTS_DIR},${PYTEST_COV_MIN})
 
 test-small: podman-check
-	@mkdir -p logs
 	$(call run_tests,${TESTS_DIR}/small)
 
 test-medium: podman-check
-	@mkdir -p logs
 	$(call run_tests,${TESTS_DIR}/medium)
 
 test-large: podman-check
-	@mkdir -p logs
 	$(call run_tests,${TESTS_DIR}/large)
 
 test-module: podman-check

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 A GraphQL API for [chronicler](https://github.com/cathyhulu/chronicler) with Neo4j database integration.
 
+## Overview
+
+Chronicler-backend is a knowledge graph system for historical events and narratives. Historical events are stored on a Neo4j knowledge graph, where a sentence transformer model generates vector embeddings for semantic search capabilities. The system features:
+
+- **Knowledge Graph Storage**: Historical events, people, places, and their relationships are modeled as interconnected nodes in a Neo4j graph database, enabling complex queries across linked data
+- **Vector Embeddings**: Utilizes optimized and quantized sentence transformer models to generate semantic vector representations of textual content
+- **Semantic Search**: Find historically related entities and events based on semantic meaning rather than just keyword matching
+- **GraphQL API**: Flexible, strongly-typed API that allows for precise queries and mutations with minimal over-fetching
+- **Scalable Architecture**: Containerized deployment with Docker/Podman for consistent development and production environments
+
+This backend powers historical data exploration and visualization, allowing users to discover connections between historical events, people, and places through both explicit relationships and semantic similarity.
+
 ## Getting Started
 
 ### Prerequisites
@@ -153,14 +165,31 @@ For development container users:
 ├── src/                           # Source code
 │   └── chronicler_backend/
 │       ├── main.py                # FastAPI application with API endpoints
-│       ├── db/                    # Neo4j database integration and connection management   
-│       └── graphql/               # Strawberry GraphQL schema with types, queries and mutations      
+│       ├── db/                    # Neo4j database integration and connection management
+│       │   ├── neo4j.py           # Neo4j database connection and session management
+│       │   └── node.py            # Node database operations and queries
+│       ├── embeddings/            # Vector embedding functionality
+│       │   ├── api.py             # Public API for embeddings
+│       │   └── manager.py         # ModelManager for handling embeddings generation
+│       ├── graphql/               # Strawberry GraphQL schema with types, queries and mutations
+│       │   ├── mutation.py        # GraphQL mutation definitions
+│       │   ├── query.py           # GraphQL query definitions
+│       │   └── schema.py          # Main GraphQL schema configuration
+│       ├── models/                # Data models and types
+│       │   └── node.py            # Node model definitions and enums
+│       └── utils/                 # Utility functions
+│           ├── constants.py       # Application constants
+│           └── logging.py         # Logging configuration
 ├── tests/                         # Tests
-│   ├── small/                     # Small unit tests
-│   ├── medium/                    # Medium integration tests
-│   ├── large/                     # Large system tests
+│   ├── small/                     # Small unit tests (fast, no external dependencies)
+│   ├── medium/                    # Medium integration tests (DB interactions)
+│   ├── large/                     # Large system tests (full API)
 │   └── conftest.py                # Pytest fixtures and configuration
+├── model_weights/                 # Directory for storing ML model weights
+│   └── quantized-model/           # Quantized sentence transformer models
 ├── scripts/                       # Utility scripts
+│   ├── download_model.py          # Script to download and quantize ML models
+│   ├── entrypoint.sh              # Docker container entrypoint
 │   ├── run-in-container.sh        # Script to run commands in Docker/Podman container
 │   └── precommit-docker-check.sh  # Pre-commit hook to verify container status
 ├── logs/                          # Log files (gitignored)
@@ -169,6 +198,7 @@ For development container users:
 ├── Dockerfile                     # Dockerfile for FastAPI application
 ├── Makefile                       # Makefile with development commands
 ├── pyproject.toml                 # Project dependencies and configuration
+├── TODO.md                        # Project task list and goals
 └── README.md                      # Project documentation
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,12 +44,6 @@ This backend powers historical data exploration and visualization, allowing user
    - GraphiQL interface: http://localhost:8000/graphql
    - Neo4j Browser: http://localhost:7474 (Define username and password `.env`)
 
-## Alternative: Local Development
-
-For a simpler development workflow (especially for IDE integration)
-
-1) Install [uv](https://docs.astral.sh/uv/getting-started/installation/)
-2) Run `make setup-local-dev` to create a venv and install dependencies
 
 ## Development Workflow
 
@@ -100,34 +94,13 @@ make docker-shell
 - Run specific module: `make test-module TEST_PATH=tests/small/test_module.py`
 - Run specific test: `make test-case TEST_PATH=tests/small/test_module.py TEST_CASE="test_function"`
 
-### Local Development (Simpler Option)
+### Local Development
 
-For a more straightforward workflow with better IDE integration:
+For installation of just python dependencies (largely for IDE integration)
 
-```bash
-# Set up local virtual environment
-make setup-local-dev
+1) Install [uv](https://docs.astral.sh/uv/getting-started/installation/)
+2) Run `make-setup-local-dev`
 
-# Start just the Neo4j services
-make neo4j-only
-
-# Run linting locally
-uv run black .
-uv run isort .
-uv run flake8
-uv run pylint **/*.py
-
-# Run tests locally
-PYTHONPATH=./src uv run pytest tests/small
-```
-
-This approach provides:
-- Faster development cycles
-- Simpler IDE integration (code navigation, autocomplete)
-- Native execution of pre-commit hooks
-- Local control of Python tooling
-
-**Note:** You'll still need Neo4j running for database operations. Use `make neo4j-only` to start just the database containers.
 
 ### Database Access
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       dockerfile: Dockerfile
       args:
         - ENV=${ENV:-production}
+        - MODEL_DIR=/app/model_weights
     container_name: chronicler-backend
     ports:
       - "${FASTAPI_PORT:-8000}:8000"
@@ -67,9 +68,6 @@ services:
       - FASTAPI_PORT=${FASTAPI_PORT:-8000}
       - FASTAPI_RELOAD=${FASTAPI_RELOAD:-true}
       - FASTAPI_DEBUG=${FASTAPI_DEBUG:-true}
-      - ENV=${ENV:-production}
-      - MODEL_DIR=/app/model_weights
-      - PYTHONPATH=/app
     volumes:
       - .:/app
       - api_packages:/app/.venv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,6 @@ services:
     volumes:
       - .:/app
       - api_packages:/app/.venv
-      - model_weights_volume:/app/model_weights
     depends_on:
       neo4j:
         condition: service_healthy
@@ -103,6 +102,4 @@ volumes:
   neo4j_data:
     driver: local
   api_packages:
-    driver: local
-  model_weights_volume:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,11 @@ services:
       timeout: 5s
       retries: 5
     restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   # Neo4j database for testing
   neo4j-test:
@@ -35,6 +40,11 @@ services:
     networks:
       - chronicler-network
     restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   # FastAPI backend using UV with Python 3.12
   api:
@@ -66,6 +76,11 @@ services:
       - chronicler-network
     command: ["uvicorn", "src.chronicler_backend.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
     restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
 networks:
   chronicler-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        - ENV=${ENV:-production}
     container_name: chronicler-backend
     ports:
       - "${FASTAPI_PORT:-8000}:8000"
@@ -65,16 +67,29 @@ services:
       - FASTAPI_PORT=${FASTAPI_PORT:-8000}
       - FASTAPI_RELOAD=${FASTAPI_RELOAD:-true}
       - FASTAPI_DEBUG=${FASTAPI_DEBUG:-true}
-      - ENV=${ENV:-development}
+      - ENV=${ENV:-production}
+      - MODEL_DIR=/app/model_weights
+      - PYTHONPATH=/app
     volumes:
       - .:/app
       - api_packages:/app/.venv
+      - model_weights_volume:/app/model_weights
     depends_on:
       neo4j:
         condition: service_healthy
     networks:
       - chronicler-network
-    command: ["uvicorn", "src.chronicler_backend.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+    command: >
+      sh -c "
+        . /app/.venv/bin/activate &&
+        if [ \"${ENV}\" = \"development\" ] || [ \"${ENV}\" = \"local\" ]; then
+          echo \"Starting in development mode with hot reload\" &&
+          uvicorn src.chronicler_backend.main:app --host 0.0.0.0 --port 8000 --reload;
+        else
+          echo \"Starting in production mode\" &&
+          uvicorn src.chronicler_backend.main:app --host 0.0.0.0 --port 8000;
+        fi
+      "
     restart: unless-stopped
     logging:
       driver: "json-file"
@@ -90,4 +105,6 @@ volumes:
   neo4j_data:
     driver: local
   api_packages:
+    driver: local
+  model_weights_volume:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,25 +68,16 @@ services:
       - FASTAPI_PORT=${FASTAPI_PORT:-8000}
       - FASTAPI_RELOAD=${FASTAPI_RELOAD:-true}
       - FASTAPI_DEBUG=${FASTAPI_DEBUG:-true}
+      - ENV=${ENV:-development}
     volumes:
       - .:/app
       - api_packages:/app/.venv
+      - model_weights:/app/model_weights
     depends_on:
       neo4j:
         condition: service_healthy
     networks:
       - chronicler-network
-    command: >
-      sh -c "
-        . /app/.venv/bin/activate &&
-        if [ \"${ENV}\" = \"development\" ] || [ \"${ENV}\" = \"local\" ]; then
-          echo \"Starting in development mode with hot reload\" &&
-          uvicorn src.chronicler_backend.main:app --host 0.0.0.0 --port 8000 --reload;
-        else
-          echo \"Starting in production mode\" &&
-          uvicorn src.chronicler_backend.main:app --host 0.0.0.0 --port 8000;
-        fi
-      "
     restart: unless-stopped
     logging:
       driver: "json-file"
@@ -102,4 +93,6 @@ volumes:
   neo4j_data:
     driver: local
   api_packages:
+    driver: local
+  model_weights:
     driver: local

--- a/model_weights/.gitignore
+++ b/model_weights/.gitignore
@@ -1,0 +1,4 @@
+# Ignore all files in this folder
+*
+# But do not ignore this .gitignore file
+!.gitignore

--- a/model_weights/.gitignore
+++ b/model_weights/.gitignore
@@ -1,4 +1,0 @@
-# Ignore all files in this folder
-*
-# But do not ignore this .gitignore file
-!.gitignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dev = [
 ]
 test = [
     "pytest>=8.3.4",
+    "pytest-asyncio>=0.26.0",
     "pytest-cov>=6.0.0",
     "pytest-mock>=3.14.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "strawberry-graphql[debug-server,fastapi]>=0.257.0",
     "neo4j>=5.13.0",
     "python-dotenv>=1.0.0",
+    "sentence-transformers[onnx]>=3.2.0",
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,7 @@ extend-exclude = "notebooks"
 [tool.isort]
 skip = ["__init__.py", ".venv"]
 profile = "black"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"

--- a/scripts/download_model.py
+++ b/scripts/download_model.py
@@ -7,11 +7,11 @@ import os
 import sys
 from pathlib import Path
 
+from chronicler_backend.embeddings.api import export_quantized_model
 from chronicler_backend.utils.constants import (
     DEFAULT_MODEL_NAME,
     DEFAULT_QUANTIZED_DIR,
 )
-from chronicler_backend.utils.embeddings import export_quantized_model
 from chronicler_backend.utils.logging import get_logger
 
 logger = get_logger(__name__)

--- a/scripts/download_model.py
+++ b/scripts/download_model.py
@@ -53,7 +53,12 @@ def main():
     # Create output directory if it doesn't exist
     output_path.mkdir(parents=True, exist_ok=True)
 
-    if output_path.exists() and list(output_path.glob("**/*.onnx")) and not args.force:
+    if (
+        output_path.exists()
+        and list(output_path.glob("**/*.onnx"))
+        and list(output_path.glob("**/config.json"))
+        and not args.force
+    ):
         logger.info(f"Model already exists at {output_path}. Use --force to redownload.")
         sys.exit(0)
 

--- a/scripts/download_model.py
+++ b/scripts/download_model.py
@@ -3,14 +3,15 @@
 Script to download and quantize the sentence transformer model.
 """
 import argparse
+import os
 import sys
 from pathlib import Path
 
-from chronicler_backend.utils.embeddings import (
+from chronicler_backend.utils.constants import (
     DEFAULT_MODEL_NAME,
     DEFAULT_QUANTIZED_DIR,
-    export_quantized_model,
 )
+from chronicler_backend.utils.embeddings import export_quantized_model
 from chronicler_backend.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -36,18 +37,37 @@ def main():
     parser.add_argument(
         "--force", action="store_true", help="Force download even if the model already exists"
     )
+    parser.add_argument("--verbose", action="store_true", help="Print verbose output for debugging")
 
     args = parser.parse_args()
     output_path = Path(args.output_dir)
+
+    # Print information for debugging
+    if args.verbose:
+        logger.debug(f"Model name: {args.model}")
+        logger.debug(f"Output directory: {output_path}")
+        logger.debug(f"Force download: {args.force}")
+        logger.debug(f"Environment variables: MODEL_DIR={os.environ.get('MODEL_DIR', 'Not set')}")
+        logger.debug(f"Current working directory: {os.getcwd()}")
+
+    # Create output directory if it doesn't exist
+    output_path.mkdir(parents=True, exist_ok=True)
 
     if output_path.exists() and list(output_path.glob("**/*.onnx")) and not args.force:
         logger.info(f"Model already exists at {output_path}. Use --force to redownload.")
         sys.exit(0)
 
     logger.info(f"Downloading and quantizing model {args.model} to {output_path}")
+
     try:
-        export_quantized_model(output_dir=args.output_dir, model_name=args.model)
-        logger.info("Model download and quantization complete!")
+        export_quantized_model(output_dir=str(args.output_dir), model_name=args.model)
+        logger.debug("Model download and quantization complete!")
+
+        # List directory contents to verify
+        if args.verbose:
+            logger.debug("Directory contents:")
+            for item in output_path.glob("**/*"):
+                logger.debug(f"  {item}")
     except Exception as e:
         logger.error(f"Error downloading/quantizing model: {e}")
         sys.exit(1)

--- a/scripts/download_model.py
+++ b/scripts/download_model.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+Script to download and quantize the sentence transformer model.
+"""
+import argparse
+import sys
+from pathlib import Path
+
+from chronicler_backend.utils.embeddings import (
+    DEFAULT_MODEL_NAME,
+    DEFAULT_QUANTIZED_DIR,
+    export_quantized_model,
+)
+from chronicler_backend.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def main():
+    """Download and quantize the model."""
+    parser = argparse.ArgumentParser(
+        description="Download and quantize a sentence transformer model for Chronicler"
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=DEFAULT_MODEL_NAME,
+        help=f"Model name to download (default: {DEFAULT_MODEL_NAME})",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=str(DEFAULT_QUANTIZED_DIR),
+        help=f"Output directory for the quantized model (default: {DEFAULT_QUANTIZED_DIR})",
+    )
+    parser.add_argument(
+        "--force", action="store_true", help="Force download even if the model already exists"
+    )
+
+    args = parser.parse_args()
+    output_path = Path(args.output_dir)
+
+    if output_path.exists() and list(output_path.glob("**/*.onnx")) and not args.force:
+        logger.info(f"Model already exists at {output_path}. Use --force to redownload.")
+        sys.exit(0)
+
+    logger.info(f"Downloading and quantizing model {args.model} to {output_path}")
+    try:
+        export_quantized_model(output_dir=args.output_dir, model_name=args.model)
+        logger.info("Model download and quantization complete!")
+    except Exception as e:
+        logger.error(f"Error downloading/quantizing model: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+# Activate the virtual environment
+. /app/.venv/bin/activate
+
+# Set default model directory if not provided
+MODEL_DIR=${MODEL_DIR:-/app/model_weights}
+QUANTIZED_MODEL_DIR="${MODEL_DIR}/quantized-model"
+
+# Create model directory if it doesn't exist
+mkdir -p ${MODEL_DIR}
+
+# Download quantized model if it doesn't exist
+uv run scripts/download_model.py --output-dir ${QUANTIZED_MODEL_DIR} --verbose
+
+
+# Launch the application based on the environment
+if [ "${ENV}" = "development" ] || [ "${ENV}" = "local" ]; then
+    echo "Starting in development mode with hot reload"
+    exec uvicorn src.chronicler_backend.main:app --host 0.0.0.0 --port 8000 --reload
+else
+    echo "Starting in production mode"
+    exec uvicorn src.chronicler_backend.main:app --host 0.0.0.0 --port 8000
+fi

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -14,12 +14,21 @@ mkdir -p ${MODEL_DIR}
 # Download quantized model if it doesn't exist
 uv run scripts/download_model.py --output-dir ${QUANTIZED_MODEL_DIR} --verbose
 
+# Set FastAPI configuration from environment variables
+# These come from .env via docker-compose.yml
+HOST=${FASTAPI_HOST:-0.0.0.0}
+PORT=${FASTAPI_PORT:-8000}
+WORKERS=${FASTAPI_WORKERS:-4}
+WORKER_TIMEOUT=${FASTAPI_WORKER_TIMEOUT:-60}
+DEBUG=${FASTAPI_DEBUG:-false}
+RELOAD=${FASTAPI_RELOAD:-false}
 
 # Launch the application based on the environment
 if [ "${ENV}" = "development" ] || [ "${ENV}" = "local" ]; then
     echo "Starting in development mode with hot reload"
-    exec uvicorn src.chronicler_backend.main:app --host 0.0.0.0 --port 8000 --reload
+    exec uvicorn src.chronicler_backend.main:app --host ${HOST} --port ${PORT} --reload ${RELOAD}
 else
-    echo "Starting in production mode"
-    exec uvicorn src.chronicler_backend.main:app --host 0.0.0.0 --port 8000
+    echo "Starting in production mode with ${WORKERS} workers"
+    exec gunicorn src.chronicler_backend.main:app -w ${WORKERS} -k uvicorn.workers.UvicornWorker \
+        --timeout ${WORKER_TIMEOUT} -b ${HOST}:${PORT}
 fi

--- a/src/chronicler_backend/db/node.py
+++ b/src/chronicler_backend/db/node.py
@@ -390,6 +390,10 @@ class NodeDatabase:
 
         Returns:
             bool: True if successful, False otherwise
+
+        Raises:
+            ValueError: If the existing index dimensions do not match the expected dimensions
+            Exception: If any error occurs during index creation
         """
         try:
             # Check if index exists using the correct syntax
@@ -401,7 +405,21 @@ class NodeDatabase:
 
             # If results are returned, the index exists
             if result and len(result) > 0:
-                logger.info("Vector index already exists")
+                # Check dimensions of existing index
+                existing_index = result[0]
+                if (
+                    "indexConfig" in existing_index
+                    and "vector.dimensions" in existing_index["indexConfig"]
+                ):
+                    existing_dimensions = existing_index["indexConfig"]["vector.dimensions"]
+                    if existing_dimensions != VECTOR_DIMENSION:
+                        error_msg = (
+                            f"Vector index dimension mismatch: Expected {VECTOR_DIMENSION}"
+                            f" but found {existing_dimensions}. Consider redeploying your database."
+                        )
+                        logger.error(error_msg)
+                        raise ValueError(error_msg)
+                logger.info("Vector index already exists with correct dimensions")
                 return True
 
             # Create vector index with IF NOT EXISTS to make it idempotent

--- a/src/chronicler_backend/db/node.py
+++ b/src/chronicler_backend/db/node.py
@@ -294,47 +294,60 @@ class NodeDatabase:
             return False
 
     def get_node_neighbors(
-        self, uuid: str, same_type_only: bool = True, limit: int = 10, offset: int = 0
+        self,
+        uuid: str,
+        same_type_only: bool = True,
+        rank_filter: str = None,
+        limit: int = 10,
+        offset: int = 0,
     ) -> List[Node]:
         """Get all neighbors of a node.
 
         Args:
             uuid: Node UUID
-            same_type_only: Only return nodes of the same type
+            same_type_only: Only return nodes of the same type. Overriden by rank_filter
+            rank_filter: Filter by node type rank. Options: "higher", "lower", "higher_equal",
+                        "lower_equal", or None for no rank filtering
             limit: Maximum number of results
             offset: Offset for pagination
 
         Returns:
             List[Node]: List of neighbor nodes
         """
-        # Query to get neighbors, with optional type filtering
-        if same_type_only:
-            query = """
-            MATCH (n:Node {uuid: $uuid})-[r]-(neighbor:Node)
-            WHERE neighbor.node_type = n.node_type
-            RETURN neighbor.uuid as uuid, neighbor.name as name,
-                   neighbor.node_type as node_type, neighbor.description as description,
-                   neighbor.node_type_rank as node_type_rank,
-                   neighbor.date_range_start as date_range_start,
-                   neighbor.date_range_end as date_range_end,
-                   neighbor.vector_embedding as vector_embedding
-            ORDER BY neighbor.name
-            SKIP $offset
-            LIMIT $limit
-            """
+        # Build the base query
+        query = """
+        MATCH (n:Node {uuid: $uuid})-[r]-(neighbor:Node)
+        """
+
+        if rank_filter == "higher":
+            where_clause = "neighbor.node_type_rank > n.node_type_rank"
+        elif rank_filter == "lower":
+            where_clause = "neighbor.node_type_rank < n.node_type_rank"
+        elif rank_filter == "higher_equal":
+            where_clause = "neighbor.node_type_rank >= n.node_type_rank"
+        elif rank_filter == "lower_equal":
+            where_clause = "neighbor.node_type_rank <= n.node_type_rank"
+        elif same_type_only:
+            where_clause = "neighbor.node_type = n.node_type"
         else:
-            query = """
-            MATCH (n:Node {uuid: $uuid})-[r]-(neighbor:Node)
-            RETURN neighbor.uuid as uuid, neighbor.name as name,
-                   neighbor.node_type as node_type, neighbor.description as description,
-                   neighbor.node_type_rank as node_type_rank,
-                   neighbor.date_range_start as date_range_start,
-                   neighbor.date_range_end as date_range_end,
-                   neighbor.vector_embedding as vector_embedding
-            ORDER BY neighbor.name
-            SKIP $offset
-            LIMIT $limit
-            """
+            where_clause = ""
+
+        # Add WHERE clause if we have conditions
+        if where_clause:
+            query += f"\nWHERE {where_clause}"
+
+        # Complete the query with the common parts
+        query += """
+        RETURN neighbor.uuid as uuid, neighbor.name as name,
+            neighbor.node_type as node_type, neighbor.description as description,
+            neighbor.node_type_rank as node_type_rank,
+            neighbor.date_range_start as date_range_start,
+            neighbor.date_range_end as date_range_end,
+            neighbor.vector_embedding as vector_embedding
+        ORDER BY neighbor.name
+        SKIP $offset
+        LIMIT $limit
+        """
 
         try:
             results = self.db.run_query(query, {"uuid": uuid, "limit": limit, "offset": offset})

--- a/src/chronicler_backend/db/node.py
+++ b/src/chronicler_backend/db/node.py
@@ -5,12 +5,13 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
 from chronicler_backend.db.neo4j import Neo4jDatabase
+from chronicler_backend.embeddings.api import get_model_manager
+from chronicler_backend.embeddings.manager import ModelManager
 from chronicler_backend.models.node import DateRange, Node, NodeType, RelationshipType
 from chronicler_backend.utils.constants import (
     TRUNCATE_DESCRIPTION_LENGTH,
     VECTOR_DIMENSION,
 )
-from chronicler_backend.utils.embeddings import model_manager
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +44,17 @@ class NodeDatabase:
             db: Neo4j database connection
         """
         self.db = db
+        self._model_manager = None
+
+    async def _get_model_manager(self) -> ModelManager:
+        """Get the ModelManager instance asynchronously.
+
+        Returns:
+            ModelManager: The model manager instance
+        """
+        if self._model_manager is None:
+            self._model_manager = await get_model_manager()
+        return self._model_manager
 
     def _format_date_range_as_string(self, date_range: Optional[DateRange]) -> str:
         """Format a date range as a string for embedding generation.
@@ -67,7 +79,7 @@ class NodeDatabase:
             return f"until {end_fmt}"
         return ""
 
-    def _generate_vector_embedding(self, node: Node) -> Optional[List[float]]:
+    async def _generate_vector_embedding(self, node: Node) -> Optional[List[float]]:
         """Generate a vector embedding for a node based on its properties.
 
         Args:
@@ -77,6 +89,9 @@ class NodeDatabase:
             Optional[List[float]]: Generated vector embedding or None if generation failed
         """
         try:
+            # Get the model manager
+            model_manager = await self._get_model_manager()
+
             # Format date range as string for embedding
             date_str = self._format_date_range_as_string(node.date_range)
 
@@ -100,7 +115,7 @@ class NodeDatabase:
             logger.error(f"Error generating vector embedding: {e}")
             return None
 
-    def create_node(self, node: Node) -> Optional[Node]:
+    async def create_node(self, node: Node) -> Optional[Node]:
         """Create a new node in the database.
 
         Args:
@@ -128,7 +143,7 @@ class NodeDatabase:
 
         # Generate vector embedding if not provided
         if node.vector_embedding is None:
-            node.vector_embedding = self._generate_vector_embedding(node)
+            node.vector_embedding = await self._generate_vector_embedding(node)
 
         # Handle vector embedding as a separate parameter if present
         vector_param = {}
@@ -220,7 +235,7 @@ class NodeDatabase:
             or node.date_range != existing.date_range
         )
 
-    def update_node(self, node: Node) -> Optional[Node]:
+    async def update_node(self, node: Node) -> Optional[Node]:
         """Update an existing node."""
         # Check if node exists
         existing = self.get_node(node.uuid)
@@ -234,7 +249,7 @@ class NodeDatabase:
         # Handle vector embedding
         vector_param = {}
         if node.vector_embedding is None and self._should_update_embedding(node, existing):
-            node.vector_embedding = self._generate_vector_embedding(node)
+            node.vector_embedding = await self._generate_vector_embedding(node)
 
         if node.vector_embedding:
             vector_param = {"vector": node.vector_embedding}

--- a/src/chronicler_backend/db/node.py
+++ b/src/chronicler_backend/db/node.py
@@ -6,7 +6,11 @@ from typing import Any, Dict, List, Optional, Union
 
 from chronicler_backend.db.neo4j import Neo4jDatabase
 from chronicler_backend.models.node import DateRange, Node, NodeType, RelationshipType
-from chronicler_backend.utils.constants import VECTOR_DIMENSION
+from chronicler_backend.utils.constants import (
+    TRUNCATE_DESCRIPTION_LENGTH,
+    VECTOR_DIMENSION,
+)
+from chronicler_backend.utils.embeddings import model_manager
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +44,62 @@ class NodeDatabase:
         """
         self.db = db
 
+    def _format_date_range_as_string(self, date_range: Optional[DateRange]) -> str:
+        """Format a date range as a string for embedding generation.
+
+        Args:
+            date_range: DateRange object to format
+
+        Returns:
+            str: Formatted date range string, or empty string if date_range is None
+        """
+        if not date_range:
+            return ""
+
+        start_fmt = date_range.start.strftime("%Y-%m-%d") if date_range.start else ""
+        end_fmt = date_range.end.strftime("%Y-%m-%d") if date_range.end else ""
+
+        if start_fmt and end_fmt:
+            return f"{start_fmt} to {end_fmt}"
+        elif start_fmt:
+            return f"from {start_fmt}"
+        elif end_fmt:
+            return f"until {end_fmt}"
+        return ""
+
+    def _generate_vector_embedding(self, node: Node) -> Optional[List[float]]:
+        """Generate a vector embedding for a node based on its properties.
+
+        Args:
+            node: Node to generate an embedding for
+
+        Returns:
+            Optional[List[float]]: Generated vector embedding or None if generation failed
+        """
+        try:
+            # Format date range as string for embedding
+            date_str = self._format_date_range_as_string(node.date_range)
+
+            # Truncate description if too long
+            if node.description and len(node.description.split()) > TRUNCATE_DESCRIPTION_LENGTH:
+                node.description = " ".join(node.description.split()[:TRUNCATE_DESCRIPTION_LENGTH])
+
+            # Prepare text for embedding
+            embedding_text = model_manager.prepare_node_text(
+                name=node.name,
+                node_type=node.node_type.name,
+                date_range=date_str,
+                description=node.description or "",
+            )
+
+            # Generate embedding
+            embedding = model_manager.encode(embedding_text)
+            logger.info(f"Generated vector embedding for node {node.name}")
+            return embedding
+        except Exception as e:
+            logger.error(f"Error generating vector embedding: {e}")
+            return None
+
     def create_node(self, node: Node) -> Optional[Node]:
         """Create a new node in the database.
 
@@ -65,6 +125,10 @@ class NodeDatabase:
         # Handle node_type
         node_data["node_type"] = node.node_type.name
         node_data["node_type_rank"] = node.node_type.value
+
+        # Generate vector embedding if not provided
+        if node.vector_embedding is None:
+            node.vector_embedding = self._generate_vector_embedding(node)
 
         # Handle vector embedding as a separate parameter if present
         vector_param = {}
@@ -129,22 +193,8 @@ class NodeDatabase:
             logger.error(f"Error getting node {uuid}: {e}")
             return None
 
-    def update_node(self, node: Node) -> Optional[Node]:
-        """Update an existing node.
-
-        Args:
-            node: Node with updated values
-
-        Returns:
-            Node: Updated node or None if update failed
-        """
-        # Check if node exists
-        existing = self.get_node(node.uuid)
-        if not existing:
-            logger.warning(f"Cannot update non-existent node: {node.uuid}")
-            return None
-
-        # Convert node to dictionary and prepare for update
+    def _prepare_node_data_for_update(self, node: Node) -> Dict[str, Any]:
+        """Prepare node data for update operation."""
         node_data = node.model_dump(exclude={"vector_embedding", "properties"})
 
         # Handle date range conversion for Neo4j
@@ -153,20 +203,43 @@ class NodeDatabase:
                 node_data["date_range_start"] = node.date_range.start
             if node.date_range.end:
                 node_data["date_range_end"] = node.date_range.end
-
-            # Remove the original date_range dict as we've flattened it
             node_data.pop("date_range")
 
         # Handle node_type
         node_data["node_type"] = node.node_type.name
         node_data["node_type_rank"] = node.node_type.value
 
-        # Handle vector embedding as a separate parameter if present
+        return node_data
+
+    def _should_update_embedding(self, node: Node, existing: Node) -> bool:
+        """Determine if vector embedding should be updated."""
+        return (
+            node.name != existing.name
+            or node.node_type != existing.node_type
+            or node.description != existing.description
+            or node.date_range != existing.date_range
+        )
+
+    def update_node(self, node: Node) -> Optional[Node]:
+        """Update an existing node."""
+        # Check if node exists
+        existing = self.get_node(node.uuid)
+        if not existing:
+            logger.warning(f"Cannot update non-existent node: {node.uuid}")
+            return None
+
+        # Prepare node data
+        node_data = self._prepare_node_data_for_update(node)
+
+        # Handle vector embedding
         vector_param = {}
+        if node.vector_embedding is None and self._should_update_embedding(node, existing):
+            node.vector_embedding = self._generate_vector_embedding(node)
+
         if node.vector_embedding:
             vector_param = {"vector": node.vector_embedding}
 
-        # Update the node
+        # Build and execute update query
         query = """
         MATCH (n:Node {uuid: $uuid})
         SET n += $properties
@@ -179,9 +252,9 @@ class NodeDatabase:
 
         query += """
         RETURN n.uuid as uuid, n.name as name, n.node_type as node_type,
-               n.description as description, n.node_type_rank as node_type_rank,
-               n.date_range_start as date_range_start, n.date_range_end as date_range_end,
-               n.vector_embedding as vector_embedding
+            n.description as description, n.node_type_rank as node_type_rank,
+            n.date_range_start as date_range_start, n.date_range_end as date_range_end,
+            n.vector_embedding as vector_embedding
         """
 
         try:

--- a/src/chronicler_backend/embeddings/api.py
+++ b/src/chronicler_backend/embeddings/api.py
@@ -1,0 +1,111 @@
+"""
+Module for managing sentence transformer models with ONNX support,
+providing efficient embedding generation with multi-worker support.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+from fastapi import BackgroundTasks, Depends
+from sentence_transformers import (
+    SentenceTransformer,
+    export_dynamic_quantized_onnx_model,
+)
+
+from chronicler_backend.embeddings.manager import ModelManager
+from chronicler_backend.utils.constants import (
+    DEFAULT_MODEL_NAME,
+    DEFAULT_QUANTIZATION,
+    DEFAULT_QUANTIZED_DIR,
+)
+from chronicler_backend.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def export_quantized_model(
+    output_dir: str = str(DEFAULT_QUANTIZED_DIR),
+    model_name: str = DEFAULT_MODEL_NAME,
+    quantization_config: str = DEFAULT_QUANTIZATION,
+) -> str:
+    """
+    Export a dynamically quantized ONNX model.
+
+    Args:
+        output_dir: Directory to save the quantized model
+        model_name: Name of the model to quantize
+        quantization_config: Configuration for quantization, auto-determined if None
+
+    Returns:
+        Path to the exported model
+    """
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # 1. First load the model with standard PyTorch backend
+    model = SentenceTransformer(model_name)
+
+    # 2. Save the base model files to the output directory
+    model.save(output_dir)
+
+    # 3. Now load with ONNX backend and export the quantized model
+    try:
+        onnx_model = SentenceTransformer(model_name, backend="onnx")
+
+        # Export the quantized model directly to the output directory
+        export_dynamic_quantized_onnx_model(
+            model=onnx_model,
+            model_name_or_path=output_dir,
+            quantization_config=quantization_config,
+        )
+
+        # Verify the export was successful
+        logger.info(f"Successfully exported quantized model to {output_dir}")
+        for item in output_path.glob("**/*"):
+            logger.debug(f"  {item}")
+
+        return output_dir
+    except Exception as e:
+        logger.error(f"Error exporting quantized model: {e}")
+        # Make sure to return the original model path for fallback
+        return output_dir
+
+
+async def get_model_manager() -> ModelManager:
+    """
+    FastAPI dependency for getting the ModelManager instance.
+
+    Returns:
+        ModelManager: Singleton instance of the ModelManager
+    """
+    return ModelManager()
+
+
+def load_model_in_background(
+    background_tasks: BackgroundTasks,
+    model_manager: ModelManager = Depends(get_model_manager),
+    model_path: Optional[str] = None,
+    quantized: bool = True,
+    backend: str = "onnx",
+) -> None:
+    """
+    Schedule model loading as a background task.
+
+    Args:
+        background_tasks: FastAPI BackgroundTasks object
+        model_manager: ModelManager instance
+        model_path: Path to the model
+        quantized: Whether to use a quantized model
+        backend: Backend to use
+    """
+    background_tasks.add_task(
+        model_manager.load_model, model_path=model_path, quantized=quantized, backend=backend
+    )
+
+
+def load_model_on_startup() -> None:
+    """
+    Function to be called during app startup to preload the model.
+    """
+    model_manager = ModelManager()
+    model_manager.load_model()

--- a/src/chronicler_backend/embeddings/manager.py
+++ b/src/chronicler_backend/embeddings/manager.py
@@ -49,7 +49,7 @@ class ModelManager(metaclass=SingletonMeta):
         model_path: Optional[str] = None,
         quantized: bool = True,
         backend: str = "onnx",
-        verbose: bool = True,
+        verbose: bool = False,
     ) -> None:
         """
         Load the sentence transformer model with ONNX backend.

--- a/src/chronicler_backend/embeddings/manager.py
+++ b/src/chronicler_backend/embeddings/manager.py
@@ -6,6 +6,7 @@ providing efficient embedding generation with multi-worker support.
 from pathlib import Path
 from typing import List, Optional
 
+from fastapi import BackgroundTasks, Depends
 from sentence_transformers import (
     SentenceTransformer,
     export_dynamic_quantized_onnx_model,
@@ -22,9 +23,21 @@ from chronicler_backend.utils.logging import get_logger
 logger = get_logger(__name__)
 
 
-class ModelManager:
+class SingletonMeta(type):
+    """Metaclass for implementing the Singleton pattern."""
+
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            logger.info(f"Creating new singleton instance of {cls.__name__}")
+            cls._instances[cls] = super().__call__(*args, **kwargs)
+        return cls._instances[cls]
+
+
+class ModelManager(metaclass=SingletonMeta):
     """
-    Singleton manager for sentence transformer models that supports
+    Manager for sentence transformer models that supports
     efficient memory usage across multiple FastAPI workers.
     """
 
@@ -32,7 +45,11 @@ class ModelManager:
         self._model: Optional[SentenceTransformer] = None
 
     def load_model(
-        self, model_path: Optional[str] = None, quantized: bool = True, backend: str = "onnx"
+        self,
+        model_path: Optional[str] = None,
+        quantized: bool = True,
+        backend: str = "onnx",
+        verbose: bool = True,
     ) -> None:
         """
         Load the sentence transformer model with ONNX backend.
@@ -48,21 +65,38 @@ class ModelManager:
         if model_path is None:
             model_path = str(DEFAULT_QUANTIZED_DIR if quantized else DEFAULT_MODEL_NAME)
 
+        if verbose:
+            logger.info(f"Current working directory: {Path.cwd()}")
+            logger.info(f"Loading model from {model_path} with backend {backend}")
+            logger.info(f"Quantized: {quantized}")
+            logger.info(f"Model path: {model_path}")
+            logger.info(f"Directory contents for {model_path}:")
+
         try:
-            # For ONNX models, we need to specify the file path relative to the model directory
+            for item in Path(model_path).iterdir():
+                logger.info(f"  {item}")
+
             if quantized and backend == "onnx":
-                # Point to the exact ONNX file in the onnx subdirectory
-                model_kwargs = {
-                    "file_name": "onnx/model_quint8_avx2.onnx",
-                    "provider": "CPUExecutionProvider",
-                }
-                self._model = SentenceTransformer(
-                    model_path, backend=backend, model_kwargs=model_kwargs
-                )
-                logger.info(f"Loaded quantized model from {model_path}")
-            else:
-                self._model = SentenceTransformer(model_path, backend=backend)
-                logger.info(f"Loaded standard model ({backend = }) from {model_path}")
+                # Try to find the ONNX model file
+                model_dir = Path(model_path)
+                onnx_files = list(model_dir.glob("**/*.onnx"))
+
+                if onnx_files:
+                    # Use the first ONNX file found
+                    relative_path = onnx_files[0].relative_to(model_dir)
+                    model_kwargs = {
+                        "file_name": str(relative_path),
+                        "provider": "CPUExecutionProvider",
+                    }
+                    self._model = SentenceTransformer(
+                        model_path, backend=backend, model_kwargs=model_kwargs
+                    )
+                else:
+                    # No ONNX files found, fall back to standard model
+                    logger.error(
+                        f"No ONNX model files in {model_path}. Falling back to standard model."
+                    )
+                    self._model = SentenceTransformer(DEFAULT_MODEL_NAME)
         except Exception as e:
             # Log the error and fall back to the non-quantized model
             logger.error(
@@ -166,6 +200,44 @@ def export_quantized_model(
         return output_dir
 
 
-# Create an instance of ModelManager
-# TODO: REMOVE AFTER MIGRATION TO CELERY WORKER
-model_manager = ModelManager()
+# FastAPI dependency to get model manager
+async def get_model_manager() -> ModelManager:
+    """
+    FastAPI dependency for getting the ModelManager instance.
+
+    Returns:
+        ModelManager: Singleton instance of the ModelManager
+    """
+    return ModelManager()
+
+
+# FastAPI background task for loading the model
+def load_model_in_background(
+    background_tasks: BackgroundTasks,
+    model_manager: ModelManager = Depends(get_model_manager),
+    model_path: Optional[str] = None,
+    quantized: bool = True,
+    backend: str = "onnx",
+) -> None:
+    """
+    Schedule model loading as a background task.
+
+    Args:
+        background_tasks: FastAPI BackgroundTasks object
+        model_manager: ModelManager instance
+        model_path: Path to the model
+        quantized: Whether to use a quantized model
+        backend: Backend to use
+    """
+    background_tasks.add_task(
+        model_manager.load_model, model_path=model_path, quantized=quantized, backend=backend
+    )
+
+
+# Function to load model during app startup
+def load_model_on_startup() -> None:
+    """
+    Function to be called during app startup to preload the model.
+    """
+    model_manager = ModelManager()
+    model_manager.load_model()

--- a/src/chronicler_backend/graphql/mutation.py
+++ b/src/chronicler_backend/graphql/mutation.py
@@ -18,31 +18,46 @@ from chronicler_backend.utils.logging import get_logger
 logger = get_logger(__name__)
 
 
-@strawberry.input
+@strawberry.input(description="Input type for date range creation and updates")
 class DateRangeInput:
     """Input type for date range creation/updates."""
 
-    start: Optional[datetime] = None
-    end: Optional[datetime] = None
+    start: Optional[datetime] = strawberry.field(
+        default=None, description="Start date of the range (optional)"
+    )
+    end: Optional[datetime] = strawberry.field(
+        default=None, description="End date of the range (optional)"
+    )
 
 
-@strawberry.input
+@strawberry.input(description="Input type for node creation and updates")
 class NodeInput:
     """Input type for node creation/updates."""
 
-    name: str
-    node_type: NodeType
-    description: Optional[str] = None
-    date_range: Optional[DateRangeInput] = None
-    vector_embedding: Optional[List[float]] = None
+    name: str = strawberry.field(description="Name of the node")
+    node_type: NodeType = strawberry.field(description="Type of the node (e.g., PERSON, EVENT)")
+    description: Optional[str] = strawberry.field(
+        default=None, description="Detailed description of the node"
+    )
+    date_range: Optional[DateRangeInput] = strawberry.field(
+        default=None, description="Time period associated with this node"
+    )
+    vector_embedding: Optional[List[float]] = strawberry.field(
+        default=None,
+        description=f"Vector embedding for semantic search (must be {VECTOR_DIMENSION} dimensions)",
+    )
 
 
-@strawberry.type
+@strawberry.type(description="Root mutation operations for the Chronicler API")
 class Mutation:
     """Root mutation type for GraphQL API."""
 
-    @strawberry.mutation
-    def create_node(self, info: Info, input: NodeInput) -> Node:
+    @strawberry.mutation(description="Create a new node in the knowledge graph")
+    def create_node(
+        self,
+        info: Info,
+        input: NodeInput,
+    ) -> Node:
         """Create a new node.
 
         Args:
@@ -95,8 +110,13 @@ class Mutation:
             hierarchy_rank=created_node.node_type.value,
         )
 
-    @strawberry.mutation
-    def update_node(self, info: Info, uuid: str, input: NodeInput) -> Optional[Node]:
+    @strawberry.mutation(description="Update an existing node in the knowledge graph")
+    def update_node(
+        self,
+        info: Info,
+        uuid: str,
+        input: NodeInput,
+    ) -> Optional[Node]:
         """Update an existing node.
 
         Args:
@@ -148,8 +168,12 @@ class Mutation:
             hierarchy_rank=updated_node.node_type.value,
         )
 
-    @strawberry.mutation
-    def delete_node(self, info: Info, uuid: str) -> bool:
+    @strawberry.mutation(description="Delete a node from the knowledge graph by UUID")
+    def delete_node(
+        self,
+        info: Info,
+        uuid: str,
+    ) -> bool:
         """Delete a node by UUID.
 
         Args:
@@ -164,9 +188,15 @@ class Mutation:
 
         return node_db.delete_node(uuid)
 
-    @strawberry.mutation
+    @strawberry.mutation(
+        description="Create a relationship between two nodes in the knowledge graph"
+    )
     def create_relationship(
-        self, info: Info, from_uuid: str, to_uuid: str, relationship_type: str
+        self,
+        info: Info,
+        from_uuid: str,
+        to_uuid: str,
+        relationship_type: str,
     ) -> bool:
         """Create a relationship between two nodes.
 

--- a/src/chronicler_backend/graphql/mutation.py
+++ b/src/chronicler_backend/graphql/mutation.py
@@ -8,11 +8,11 @@ import strawberry
 from strawberry.types import Info
 
 from chronicler_backend.db.node import NodeDatabase
-from chronicler_backend.graphql.query import DateRange, Node, NodeType
+from chronicler_backend.graphql.query import DateRange, Node, NodeType, RelationshipType
 from chronicler_backend.models.node import DateRange as ModelDateRange
 from chronicler_backend.models.node import Node as ModelNode
 from chronicler_backend.models.node import NodeType as ModelNodeType
-from chronicler_backend.models.node import RelationshipType
+from chronicler_backend.models.node import RelationshipType as ModelRelationshipType
 from chronicler_backend.utils.constants import VECTOR_DIMENSION
 from chronicler_backend.utils.logging import get_logger
 
@@ -227,8 +227,12 @@ class Mutation:
         node_db = NodeDatabase(db)
 
         try:
-            # Use the NodeDatabase method which accepts RelationshipType
-            return node_db.create_relationship(from_uuid, to_uuid, relationship_type)
+            # Convert the GraphQL enum to the model enum by
+            # constructing the model enum from the value
+            model_relationship_type = ModelRelationshipType(relationship_type.value)
+
+            # Use the NodeDatabase method with the converted model enum
+            return node_db.create_relationship(from_uuid, to_uuid, model_relationship_type)
         except Exception as e:
             logger.error(f"Failed to create relationship: {e}")
             return False

--- a/src/chronicler_backend/graphql/mutation.py
+++ b/src/chronicler_backend/graphql/mutation.py
@@ -12,6 +12,7 @@ from chronicler_backend.graphql.query import DateRange, Node, NodeType
 from chronicler_backend.models.node import DateRange as ModelDateRange
 from chronicler_backend.models.node import Node as ModelNode
 from chronicler_backend.models.node import NodeType as ModelNodeType
+from chronicler_backend.models.node import RelationshipType
 from chronicler_backend.utils.constants import VECTOR_DIMENSION
 from chronicler_backend.utils.logging import get_logger
 
@@ -207,7 +208,8 @@ class Mutation:
             str, strawberry.argument(description="Unique identifier of the target node")
         ],
         relationship_type: Annotated[
-            str, strawberry.argument(description="Type of relationship between the nodes")
+            RelationshipType,
+            strawberry.argument(description="Type of relationship between the nodes"),
         ],
     ) -> bool:
         """Create a relationship between two nodes.
@@ -216,30 +218,17 @@ class Mutation:
             info: GraphQL resolver info with context
             from_uuid: UUID of the source node
             to_uuid: UUID of the target node
-            relationship_type: Type of relationship
+            relationship_type: Type of relationship from RelationshipType enum
 
         Returns:
             bool: True if relationship was created, False otherwise
         """
         db = info.context["db"]
-
-        # Uppercase the relationship type for Neo4j convention
-        rel_type = relationship_type.upper().replace(" ", "_")
-
-        # Create the relationship
-        query = f"""
-        MATCH (a:Node {{uuid: $from_uuid}})
-        MATCH (b:Node {{uuid: $to_uuid}})
-        CREATE (a)-[r:`{rel_type}`]->(b)
-        RETURN count(r) as created
-        """
+        node_db = NodeDatabase(db)
 
         try:
-            result = db.run_query(
-                query, {"from_uuid": from_uuid, "to_uuid": to_uuid}, return_single=True
-            )
-
-            return result and result.get("created", 0) > 0
+            # Use the NodeDatabase method which accepts RelationshipType
+            return node_db.create_relationship(from_uuid, to_uuid, relationship_type)
         except Exception as e:
             logger.error(f"Failed to create relationship: {e}")
             return False

--- a/src/chronicler_backend/graphql/mutation.py
+++ b/src/chronicler_backend/graphql/mutation.py
@@ -2,7 +2,7 @@
 
 import uuid
 from datetime import datetime
-from typing import List, Optional
+from typing import Annotated, List, Optional
 
 import strawberry
 from strawberry.types import Info
@@ -56,7 +56,9 @@ class Mutation:
     def create_node(
         self,
         info: Info,
-        input: NodeInput,
+        input: Annotated[
+            NodeInput, strawberry.argument(description="Input data for creating a new node")
+        ],
     ) -> Node:
         """Create a new node.
 
@@ -114,8 +116,10 @@ class Mutation:
     def update_node(
         self,
         info: Info,
-        uuid: str,
-        input: NodeInput,
+        uuid: Annotated[
+            str, strawberry.argument(description="Unique identifier of the node to update")
+        ],
+        input: Annotated[NodeInput, strawberry.argument(description="Updated data for the node")],
     ) -> Optional[Node]:
         """Update an existing node.
 
@@ -172,7 +176,9 @@ class Mutation:
     def delete_node(
         self,
         info: Info,
-        uuid: str,
+        uuid: Annotated[
+            str, strawberry.argument(description="Unique identifier of the node to delete")
+        ],
     ) -> bool:
         """Delete a node by UUID.
 
@@ -194,9 +200,15 @@ class Mutation:
     def create_relationship(
         self,
         info: Info,
-        from_uuid: str,
-        to_uuid: str,
-        relationship_type: str,
+        from_uuid: Annotated[
+            str, strawberry.argument(description="Unique identifier of the source node")
+        ],
+        to_uuid: Annotated[
+            str, strawberry.argument(description="Unique identifier of the target node")
+        ],
+        relationship_type: Annotated[
+            str, strawberry.argument(description="Type of relationship between the nodes")
+        ],
     ) -> bool:
         """Create a relationship between two nodes.
 

--- a/src/chronicler_backend/graphql/mutation.py
+++ b/src/chronicler_backend/graphql/mutation.py
@@ -54,7 +54,7 @@ class Mutation:
     """Root mutation type for GraphQL API."""
 
     @strawberry.mutation(description="Create a new node in the knowledge graph")
-    def create_node(
+    async def create_node(
         self,
         info: Info,
         input: Annotated[
@@ -99,7 +99,7 @@ class Mutation:
         )
 
         # Persist to database
-        created_node = node_db.create_node(model_node)
+        created_node = await node_db.create_node(model_node)
         if not created_node:
             raise ValueError("Failed to create node")
 
@@ -114,7 +114,7 @@ class Mutation:
         )
 
     @strawberry.mutation(description="Update an existing node in the knowledge graph")
-    def update_node(
+    async def update_node(
         self,
         info: Info,
         uuid: Annotated[
@@ -148,6 +148,11 @@ class Mutation:
         # Convert GraphQL enum to model enum
         node_type = ModelNodeType[input.node_type.name]
 
+        if input.vector_embedding is not None:
+            vector_embedding = input.vector_embedding
+        else:
+            vector_embedding = existing_node.vector_embedding
+
         # Update the node model with new values
         updated_model = ModelNode(
             uuid=uuid,
@@ -155,11 +160,11 @@ class Mutation:
             node_type=node_type,
             description=input.description,
             date_range=date_range,
-            vector_embedding=input.vector_embedding or existing_node.vector_embedding,
+            vector_embedding=vector_embedding,
         )
 
-        # Persist the update
-        updated_node = node_db.update_node(updated_model)
+        # Persist the update, regenerating the vector embedding if necessary
+        updated_node = await node_db.update_node(updated_model)
         if not updated_node:
             return None
 

--- a/src/chronicler_backend/graphql/query.py
+++ b/src/chronicler_backend/graphql/query.py
@@ -10,6 +10,7 @@ from strawberry.types import Info
 from chronicler_backend.db.node import NodeDatabase
 from chronicler_backend.models.node import DateRange as ModelDateRange
 from chronicler_backend.models.node import NodeType as ModelNodeType
+from chronicler_backend.models.node import RelationshipType as ModelRelationshipType
 from chronicler_backend.utils.constants import TRUNCATE_DESCRIPTION_LENGTH
 from chronicler_backend.utils.embeddings import model_manager
 from chronicler_backend.utils.logging import get_logger
@@ -22,6 +23,24 @@ NodeTypeDict = {node_type.name: node_type.name for node_type in ModelNodeType}
 NodeType = strawberry.enum(
     enum.Enum("NodeType", NodeTypeDict), description="Types of nodes in the knowledge graph"
 )
+
+# Auto-generate RelationshipType enum for GraphQL from the model definition
+RelationshipTypeDict = {rel_type.name: rel_type.value for rel_type in ModelRelationshipType}
+RelationshipType = strawberry.enum(
+    enum.Enum("RelationshipType", RelationshipTypeDict),
+    description="Types of relationships between nodes in the knowledge graph",
+)
+
+
+# Define rank filter enum options
+@strawberry.enum(description="Options for filtering nodes by their hierarchical rank")
+class RankFilterType(enum.Enum):
+    """Enum for rank filter options when querying node neighbors."""
+
+    HIGHER = "higher"
+    LOWER = "lower"
+    HIGHER_EQUAL = "higher_equal"
+    LOWER_EQUAL = "lower_equal"
 
 
 # Auto-generate DateRange type for GraphQL from the model definition
@@ -175,6 +194,12 @@ class Query:
         same_type_only: Annotated[
             bool, strawberry.argument(description="Filter to only return nodes of the same type")
         ] = True,
+        rank_filter: Annotated[
+            Optional[RankFilterType],
+            strawberry.argument(
+                description="Filter by node type rank relative to the current node"
+            ),
+        ] = None,
         limit: Annotated[
             int, strawberry.argument(description="Maximum number of nodes to return")
         ] = 10,
@@ -188,6 +213,7 @@ class Query:
             info: GraphQL resolver info with context
             uuid: Node UUID
             same_type_only: Only return nodes of the same type
+            rank_filter: Filter by node type rank relative to the current node
             limit: Maximum number of results
             offset: Offset for pagination
 
@@ -197,8 +223,15 @@ class Query:
         db = info.context["db"]
         node_db = NodeDatabase(db)
 
+        # Convert the enum value to string if rank_filter is provided
+        rank_filter_value = rank_filter.value if rank_filter else None
+
         neighbors = node_db.get_node_neighbors(
-            uuid, same_type_only=same_type_only, limit=limit, offset=offset
+            uuid,
+            same_type_only=same_type_only,
+            rank_filter=rank_filter_value,
+            limit=limit,
+            offset=offset,
         )
 
         # Convert from model to GraphQL type

--- a/src/chronicler_backend/graphql/query.py
+++ b/src/chronicler_backend/graphql/query.py
@@ -2,7 +2,7 @@
 
 import enum
 from datetime import datetime
-from typing import List, Optional
+from typing import Annotated, List, Optional
 
 import strawberry
 from strawberry.types import Info
@@ -95,7 +95,9 @@ class Query:
     def node(
         self,
         info: Info,
-        uuid: str,
+        uuid: Annotated[
+            str, strawberry.argument(description="Unique identifier of the node to retrieve")
+        ],
     ) -> Optional[Node]:
         """Query to get a node by UUID.
 
@@ -126,8 +128,12 @@ class Query:
     def nodes(
         self,
         info: Info,
-        limit: int = 10,
-        offset: int = 0,
+        limit: Annotated[
+            int, strawberry.argument(description="Maximum number of nodes to return")
+        ] = 10,
+        offset: Annotated[
+            int, strawberry.argument(description="Number of nodes to skip for pagination")
+        ] = 0,
     ) -> List[Node]:
         """Query to get all nodes with pagination.
 
@@ -162,10 +168,19 @@ class Query:
     def node_neighbors(
         self,
         info: Info,
-        uuid: str,
-        same_type_only: bool = True,
-        limit: int = 10,
-        offset: int = 0,
+        uuid: Annotated[
+            str,
+            strawberry.argument(description="Unique identifier of the node to find neighbors for"),
+        ],
+        same_type_only: Annotated[
+            bool, strawberry.argument(description="Filter to only return nodes of the same type")
+        ] = True,
+        limit: Annotated[
+            int, strawberry.argument(description="Maximum number of nodes to return")
+        ] = 10,
+        offset: Annotated[
+            int, strawberry.argument(description="Number of nodes to skip for pagination")
+        ] = 0,
     ) -> List[Node]:
         """Query to get neighbors of a node.
 
@@ -203,11 +218,21 @@ class Query:
     def nodes_by_date_range(
         self,
         info: Info,
-        start_date: Optional[datetime] = None,
-        end_date: Optional[datetime] = None,
-        node_type: Optional[NodeType] = None,
-        limit: int = 10,
-        offset: int = 0,
+        start_date: Annotated[
+            Optional[datetime], strawberry.argument(description="Start date for date range search")
+        ] = None,
+        end_date: Annotated[
+            Optional[datetime], strawberry.argument(description="End date for date range search")
+        ] = None,
+        node_type: Annotated[
+            Optional[NodeType], strawberry.argument(description="Filter results by node type")
+        ] = None,
+        limit: Annotated[
+            int, strawberry.argument(description="Maximum number of nodes to return")
+        ] = 10,
+        offset: Annotated[
+            int, strawberry.argument(description="Number of nodes to skip for pagination")
+        ] = 0,
     ) -> List[Node]:
         """Query nodes by date range.
 
@@ -255,9 +280,15 @@ class Query:
     def search_nodes_by_vector(
         self,
         info: Info,
-        vector: List[float],
-        limit: int = 10,
-        offset: int = 0,
+        vector: Annotated[
+            List[float], strawberry.argument(description="Query vector for similarity search")
+        ],
+        limit: Annotated[
+            int, strawberry.argument(description="Maximum number of nodes to return")
+        ] = 10,
+        offset: Annotated[
+            int, strawberry.argument(description="Number of nodes to skip for pagination")
+        ] = 0,
     ) -> List[Node]:
         """Search nodes by vector similarity.
 
@@ -292,9 +323,15 @@ class Query:
     def search_nodes_by_text(
         self,
         info: Info,
-        search_text: str,
-        limit: int = 10,
-        offset: int = 0,
+        search_text: Annotated[
+            str, strawberry.argument(description="Text to search for semantic similarity")
+        ],
+        limit: Annotated[
+            int, strawberry.argument(description="Maximum number of nodes to return")
+        ] = 10,
+        offset: Annotated[
+            int, strawberry.argument(description="Number of nodes to skip for pagination")
+        ] = 0,
     ) -> List[Node]:
         """Search nodes by semantic similarity to the given text.
 

--- a/src/chronicler_backend/graphql/query.py
+++ b/src/chronicler_backend/graphql/query.py
@@ -8,11 +8,11 @@ import strawberry
 from strawberry.types import Info
 
 from chronicler_backend.db.node import NodeDatabase
+from chronicler_backend.embeddings.api import get_model_manager
 from chronicler_backend.models.node import DateRange as ModelDateRange
 from chronicler_backend.models.node import NodeType as ModelNodeType
 from chronicler_backend.models.node import RelationshipType as ModelRelationshipType
 from chronicler_backend.utils.constants import TRUNCATE_DESCRIPTION_LENGTH
-from chronicler_backend.utils.embeddings import model_manager
 from chronicler_backend.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -353,7 +353,7 @@ class Query:
         ]
 
     @strawberry.field(description="Search nodes by semantic similarity to the given text")
-    def search_nodes_by_text(
+    async def search_nodes_by_text(
         self,
         info: Info,
         search_text: Annotated[
@@ -384,6 +384,9 @@ class Query:
         node_db = NodeDatabase(db)
 
         try:
+            # Get model manager from FastAPI dependency
+            model_manager = await get_model_manager()
+
             # Generate embedding from search text
             vector = model_manager.encode(search_text)
 

--- a/src/chronicler_backend/graphql/query.py
+++ b/src/chronicler_backend/graphql/query.py
@@ -10,6 +10,10 @@ from strawberry.types import Info
 from chronicler_backend.db.node import NodeDatabase
 from chronicler_backend.models.node import DateRange as ModelDateRange
 from chronicler_backend.models.node import NodeType as ModelNodeType
+from chronicler_backend.utils.embeddings import model_manager
+from chronicler_backend.utils.logging import get_logger
+
+logger = get_logger(__name__)
 
 # Auto-generate NodeType enum for GraphQL from the model definition
 # Create the enum dynamically based on the model's NodeType
@@ -235,3 +239,50 @@ class Query:
             )
             for node in nodes
         ]
+
+    @strawberry.field
+    def search_nodes_by_text(
+        self, info: Info, search_text: str, limit: int = 10, offset: int = 0
+    ) -> List[Node]:
+        """Search nodes by semantic similarity to the given text.
+
+        This query converts the input text to a vector embedding and
+        then performs a vector similarity search.
+
+        Args:
+            info: GraphQL resolver info with context
+            search_text: Text to search for
+            limit: Maximum number of results
+            offset: Offset for pagination
+
+        Returns:
+            List[Node]: List of nodes sorted by semantic similarity
+        """
+        db = info.context["db"]
+        node_db = NodeDatabase(db)
+
+        try:
+            # Generate embedding from search text
+            vector = model_manager.encode(search_text)
+
+            # Search using the vector
+            nodes = node_db.search_nodes_by_vector_similarity(
+                vector=vector, limit=limit, offset=offset
+            )
+
+            # Convert from model to GraphQL type
+            return [
+                Node(
+                    uuid=node.uuid,
+                    name=node.name,
+                    node_type=NodeType[node.node_type.name],
+                    description=node.description,
+                    date_range=DateRange.from_model(node.date_range),
+                    hierarchy_rank=node.node_type.value,
+                )
+                for node in nodes
+            ]
+        except Exception as e:
+            # Log error but don't expose details to client
+            logger.error(f"Error in search_nodes_by_text: {e}")
+            return []

--- a/src/chronicler_backend/graphql/query.py
+++ b/src/chronicler_backend/graphql/query.py
@@ -10,6 +10,7 @@ from strawberry.types import Info
 from chronicler_backend.db.node import NodeDatabase
 from chronicler_backend.models.node import DateRange as ModelDateRange
 from chronicler_backend.models.node import NodeType as ModelNodeType
+from chronicler_backend.utils.constants import TRUNCATE_DESCRIPTION_LENGTH
 from chronicler_backend.utils.embeddings import model_manager
 from chronicler_backend.utils.logging import get_logger
 
@@ -18,17 +19,23 @@ logger = get_logger(__name__)
 # Auto-generate NodeType enum for GraphQL from the model definition
 # Create the enum dynamically based on the model's NodeType
 NodeTypeDict = {node_type.name: node_type.name for node_type in ModelNodeType}
-NodeType = strawberry.enum(enum.Enum("NodeType", NodeTypeDict))
+NodeType = strawberry.enum(
+    enum.Enum("NodeType", NodeTypeDict), description="Types of nodes in the knowledge graph"
+)
 
 
 # Auto-generate DateRange type for GraphQL from the model definition
-@strawberry.type
+@strawberry.type(description="Date range with optional start and end dates")
 class DateRange:
     """Date range type for GraphQL, auto-generated from model definition."""
 
     # Match the fields from ModelDateRange
-    start: Optional[datetime] = None
-    end: Optional[datetime] = None
+    start: Optional[datetime] = strawberry.field(
+        default=None, description="Start date of the range (optional)"
+    )
+    end: Optional[datetime] = strawberry.field(
+        default=None, description="End date of the range (optional)"
+    )
 
     @classmethod
     def from_model(cls, model_date_range: Optional[ModelDateRange]) -> Optional["DateRange"]:
@@ -45,24 +52,51 @@ class DateRange:
         return cls(start=model_date_range.start, end=model_date_range.end)
 
 
-@strawberry.type
+@strawberry.type(description="Node in the knowledge graph representing an entity or event")
 class Node:
     """Node type for GraphQL API."""
 
-    uuid: str
-    name: str
-    node_type: NodeType
-    description: Optional[str] = None
-    date_range: Optional[DateRange] = None
-    hierarchy_rank: int
+    uuid: str = strawberry.field(description="Unique identifier for the node")
+    name: str = strawberry.field(description="Name of the node")
+    node_type: NodeType = strawberry.field(description="Type of the node (e.g., PERSON, EVENT)")
+    description: Optional[str] = strawberry.field(
+        default=None, description="Detailed description of the node"
+    )
+    date_range: Optional[DateRange] = strawberry.field(
+        default=None, description="Time period associated with this node"
+    )
+    hierarchy_rank: int = strawberry.field(
+        description="Hierarchical rank in the knowledge grap (higher is more important)"
+    )
 
 
-@strawberry.type
+@strawberry.type(description="Root query operations for the Chronicler API")
 class Query:
     """Root query type for GraphQL API."""
 
-    @strawberry.field
-    def node(self, info: Info, uuid: str) -> Optional[Node]:
+    @strawberry.field(
+        description=(
+            "Get the maximum description length (in characters)"
+            " before truncation for vector embeddings"
+        )
+    )
+    def max_description_length(self, info: Info) -> int:
+        """Get the maximum description length before truncation for vector embeddings.
+
+        Args:
+            info: GraphQL resolver info with context
+
+        Returns:
+            int: Maximum number of characters before truncation
+        """
+        return TRUNCATE_DESCRIPTION_LENGTH
+
+    @strawberry.field(description="Retrieve a single node by its unique identifier")
+    def node(
+        self,
+        info: Info,
+        uuid: str,
+    ) -> Optional[Node]:
         """Query to get a node by UUID.
 
         Args:
@@ -88,8 +122,13 @@ class Query:
             )
         return None
 
-    @strawberry.field
-    def nodes(self, info: Info, limit: int = 10, offset: int = 0) -> List[Node]:
+    @strawberry.field(description="Retrieve a list of all nodes with pagination support")
+    def nodes(
+        self,
+        info: Info,
+        limit: int = 10,
+        offset: int = 0,
+    ) -> List[Node]:
         """Query to get all nodes with pagination.
 
         Args:
@@ -119,9 +158,14 @@ class Query:
             for node in nodes
         ]
 
-    @strawberry.field
+    @strawberry.field(description="Retrieve a list of neighbor nodes for a given node")
     def node_neighbors(
-        self, info: Info, uuid: str, same_type_only: bool = True, limit: int = 10, offset: int = 0
+        self,
+        info: Info,
+        uuid: str,
+        same_type_only: bool = True,
+        limit: int = 10,
+        offset: int = 0,
     ) -> List[Node]:
         """Query to get neighbors of a node.
 
@@ -155,7 +199,7 @@ class Query:
             for node in neighbors
         ]
 
-    @strawberry.field
+    @strawberry.field(description="Retrieve a list of nodes within a specified date range")
     def nodes_by_date_range(
         self,
         info: Info,
@@ -207,9 +251,13 @@ class Query:
             for node in nodes
         ]
 
-    @strawberry.field
+    @strawberry.field(description="Search nodes by vector similarity")
     def search_nodes_by_vector(
-        self, info: Info, vector: List[float], limit: int = 10, offset: int = 0
+        self,
+        info: Info,
+        vector: List[float],
+        limit: int = 10,
+        offset: int = 0,
     ) -> List[Node]:
         """Search nodes by vector similarity.
 
@@ -240,9 +288,13 @@ class Query:
             for node in nodes
         ]
 
-    @strawberry.field
+    @strawberry.field(description="Search nodes by semantic similarity to the given text")
     def search_nodes_by_text(
-        self, info: Info, search_text: str, limit: int = 10, offset: int = 0
+        self,
+        info: Info,
+        search_text: str,
+        limit: int = 10,
+        offset: int = 0,
     ) -> List[Node]:
         """Search nodes by semantic similarity to the given text.
 

--- a/src/chronicler_backend/main.py
+++ b/src/chronicler_backend/main.py
@@ -9,6 +9,7 @@ from strawberry.fastapi import GraphQLRouter
 
 from chronicler_backend.db.neo4j import Neo4jDatabase, get_db
 from chronicler_backend.db.node import NodeDatabase
+from chronicler_backend.embeddings.api import load_model_on_startup
 from chronicler_backend.graphql.schema import schema
 from chronicler_backend.utils.logging import get_logger
 
@@ -43,6 +44,11 @@ async def lifespan(app: FastAPI):
             logger.warning("Failed to set up vector index")
     except Exception as e:
         logger.warning(f"Error setting up vector index: {e}")
+
+    # Start loading the model in the background during startup
+    logger.info("Loading sentence transformer model...")
+    load_model_on_startup()
+    logger.info("Model loading initiated")
 
     yield
     # Shutdown: Add any cleanup here

--- a/src/chronicler_backend/models/node.py
+++ b/src/chronicler_backend/models/node.py
@@ -7,10 +7,7 @@ from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from chronicler_backend.utils.constants import (
-    TRUNCATE_DESCRIPTION_LENGTH,
-    VECTOR_DIMENSION,
-)
+from chronicler_backend.utils.constants import VECTOR_DIMENSION
 from chronicler_backend.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -137,24 +134,4 @@ class Node(BaseModel):
         """
         if value is not None and len(value) != VECTOR_DIMENSION:
             raise ValueError(f"Vector embedding must be of dimension {VECTOR_DIMENSION}.")
-        return value
-
-    @field_validator("description")
-    def validate_description_length(cls, value: Optional[str]) -> Optional[str]:
-        """Log a warning if description exceeds 200 words.
-
-        Args:
-            value: Description text
-
-        Returns:
-            str: Original description
-        """
-        if value is not None:
-            words = value.split()
-            if len(words) > TRUNCATE_DESCRIPTION_LENGTH:
-                logger.warning(
-                    f"Description exceeds {TRUNCATE_DESCRIPTION_LENGTH} words"
-                    f" (has {len(words)} words). Will be truncated before"
-                    " conversion to vector embedding."
-                )
         return value

--- a/src/chronicler_backend/models/node.py
+++ b/src/chronicler_backend/models/node.py
@@ -7,7 +7,13 @@ from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from chronicler_backend.utils.constants import VECTOR_DIMENSION
+from chronicler_backend.utils.constants import (
+    TRUNCATE_DESCRIPTION_LENGTH,
+    VECTOR_DIMENSION,
+)
+from chronicler_backend.utils.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class NodeType(IntEnum):
@@ -131,4 +137,24 @@ class Node(BaseModel):
         """
         if value is not None and len(value) != VECTOR_DIMENSION:
             raise ValueError(f"Vector embedding must be of dimension {VECTOR_DIMENSION}.")
+        return value
+
+    @field_validator("description")
+    def validate_description_length(cls, value: Optional[str]) -> Optional[str]:
+        """Log a warning if description exceeds 200 words.
+
+        Args:
+            value: Description text
+
+        Returns:
+            str: Original description
+        """
+        if value is not None:
+            words = value.split()
+            if len(words) > TRUNCATE_DESCRIPTION_LENGTH:
+                logger.warning(
+                    f"Description exceeds {TRUNCATE_DESCRIPTION_LENGTH} words"
+                    f" (has {len(words)} words). Will be truncated before"
+                    " conversion to vector embedding."
+                )
         return value

--- a/src/chronicler_backend/models/node.py
+++ b/src/chronicler_backend/models/node.py
@@ -77,15 +77,45 @@ class DateRange(BaseModel):
 
 
 class Node(BaseModel):
-    """Node model for graph entities."""
+    """Node model for graph entities representing historical elements."""
 
-    uuid: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    name: str
-    node_type: NodeType
-    description: Optional[str] = None
-    date_range: Optional[DateRange] = None
-    vector_embedding: Optional[List[float]] = None
-    properties: Optional[Dict] = Field(default_factory=dict)
+    uuid: str = Field(
+        default_factory=lambda: str(uuid.uuid4()),
+        description="Unique identifier for the historical entity",
+    )
+    name: str = Field(
+        ...,
+        description=(
+            "Historical name or title of the entity (e.g., 'Battle of Waterloo', 'Roman Empire')"
+        ),
+    )
+    node_type: NodeType = Field(
+        ...,
+        description=(
+            "Classification of the historical entity "
+            "(e.g., EVENT, WAR, COUNTRY, ERA) with hierarchical importance"
+        ),
+    )
+    description: Optional[str] = Field(
+        None, description="Historical description and significance of the entity"
+    )
+    date_range: Optional[DateRange] = Field(
+        None, description="Temporal period during which the historical entity existed or occurred"
+    )
+    vector_embedding: Optional[List[float]] = Field(
+        None,
+        description=(
+            "Vector representation for semantic search and similarity "
+            "between historical entities"
+        ),
+    )
+    properties: Optional[Dict] = Field(
+        default_factory=dict,
+        description=(
+            "Flexible key-value pairs for storing node-type specific attributes"
+            " that don't fit into standard fields"
+        ),
+    )
 
     model_config = ConfigDict(use_enum_values=False)
 

--- a/src/chronicler_backend/utils/constants.py
+++ b/src/chronicler_backend/utils/constants.py
@@ -10,4 +10,4 @@ from pathlib import Path
 
 ROOT_DIR = Path(__file__).resolve().parents[3]
 
-VECTOR_DIMENSION = 1536
+VECTOR_DIMENSION = 384

--- a/src/chronicler_backend/utils/constants.py
+++ b/src/chronicler_backend/utils/constants.py
@@ -6,11 +6,22 @@ Attributes:
     VECTOR_DIMENSION (int): The dimension of the vector embeddings.
     TRUNCATE_DESCRIPTION_LENGTH (int): The maximum length of the description
         before truncation for vector conversion.
+    DEFAULT_MODEL_NAME (str): The default name of the model to be used.
+    DEFAULT_MODEL_DIR (Path): The default directory for storing models.
+    DEFAULT_QUANTIZED_DIR (Path): The default directory for storing
+        quantized models.
+    DEFAULT_QUANTIZATION (str): The default quantization method to be used.
 """
 
+import os
 from pathlib import Path
 
 ROOT_DIR = Path(__file__).resolve().parents[3]
 
 VECTOR_DIMENSION = 384
 TRUNCATE_DESCRIPTION_LENGTH = 200
+
+DEFAULT_MODEL_NAME = "all-MiniLM-L6-v2"
+DEFAULT_MODEL_DIR = Path(os.environ.get("MODEL_DIR", "./models"))
+DEFAULT_QUANTIZED_DIR = DEFAULT_MODEL_DIR / "quantized-model"
+DEFAULT_QUANTIZATION = "avx2"

--- a/src/chronicler_backend/utils/constants.py
+++ b/src/chronicler_backend/utils/constants.py
@@ -4,6 +4,8 @@ Constant values for convenience
 Attributes:
     ROOT_DIR (Path): The root directory of the project.
     VECTOR_DIMENSION (int): The dimension of the vector embeddings.
+    TRUNCATE_DESCRIPTION_LENGTH (int): The maximum length of the description
+        before truncation for vector conversion.
 """
 
 from pathlib import Path
@@ -11,3 +13,4 @@ from pathlib import Path
 ROOT_DIR = Path(__file__).resolve().parents[3]
 
 VECTOR_DIMENSION = 384
+TRUNCATE_DESCRIPTION_LENGTH = 200

--- a/src/chronicler_backend/utils/embeddings.py
+++ b/src/chronicler_backend/utils/embeddings.py
@@ -3,7 +3,6 @@ Module for managing sentence transformer models with ONNX support,
 providing efficient embedding generation with multi-worker support.
 """
 
-from functools import lru_cache
 from pathlib import Path
 from typing import List, Optional
 
@@ -25,14 +24,6 @@ class ModelManager:
     Singleton manager for sentence transformer models that supports
     efficient memory usage across multiple FastAPI workers.
     """
-
-    _instance = None
-
-    def __new__(cls):
-        if cls._instance is None:
-            cls._instance = super(ModelManager, cls).__new__(cls)
-            cls._instance._model = None
-        return cls._instance
 
     def load_model(
         self, model_path: Optional[str] = None, quantized: bool = True, backend: str = "onnx"
@@ -59,11 +50,9 @@ class ModelManager:
             self.load_model()
         return self._model
 
-    @lru_cache(maxsize=1024)
     def encode(self, text: str) -> List[float]:
         """
         Generate embeddings for the given text.
-        Uses lru_cache to avoid recomputing embeddings for the same text.
 
         Args:
             text: Input text to encode
@@ -135,5 +124,6 @@ def export_quantized_model(
     return output_dir
 
 
-# Create a singleton instance
+# Create an instance of ModelManager
+# TODO: REMOVE AFTER MIGRATION TO CELERY WORKER
 model_manager = ModelManager()

--- a/src/chronicler_backend/utils/embeddings.py
+++ b/src/chronicler_backend/utils/embeddings.py
@@ -1,0 +1,139 @@
+"""
+Module for managing sentence transformer models with ONNX support,
+providing efficient embedding generation with multi-worker support.
+"""
+
+from functools import lru_cache
+from pathlib import Path
+from typing import List, Optional
+
+from sentence_transformers import (
+    SentenceTransformer,
+    export_dynamic_quantized_onnx_model,
+)
+
+from chronicler_backend.utils.constants import (
+    DEFAULT_MODEL_NAME,
+    DEFAULT_QUANTIZATION,
+    DEFAULT_QUANTIZED_DIR,
+    TRUNCATE_DESCRIPTION_LENGTH,
+)
+
+
+class ModelManager:
+    """
+    Singleton manager for sentence transformer models that supports
+    efficient memory usage across multiple FastAPI workers.
+    """
+
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(ModelManager, cls).__new__(cls)
+            cls._instance._model = None
+        return cls._instance
+
+    def load_model(
+        self, model_path: Optional[str] = None, quantized: bool = True, backend: str = "onnx"
+    ) -> None:
+        """
+        Load the sentence transformer model with ONNX backend.
+
+        Args:
+            model_path: Path to the model, defaults to DEFAULT_QUANTIZED_DIR
+            quantized: Whether to use a quantized model
+            backend: Backend to use, defaults to "onnx"
+        """
+        if self._model is not None:
+            return
+
+        if model_path is None:
+            model_path = str(DEFAULT_QUANTIZED_DIR if quantized else DEFAULT_MODEL_NAME)
+
+        self._model = SentenceTransformer(model_path, backend=backend)
+
+    def get_model(self) -> SentenceTransformer:
+        """Get the loaded model or load it if not already loaded."""
+        if self._model is None:
+            self.load_model()
+        return self._model
+
+    @lru_cache(maxsize=1024)
+    def encode(self, text: str) -> List[float]:
+        """
+        Generate embeddings for the given text.
+        Uses lru_cache to avoid recomputing embeddings for the same text.
+
+        Args:
+            text: Input text to encode
+
+        Returns:
+            Vector embedding as a list of floats
+        """
+        model = self.get_model()
+        return model.encode(text).tolist()
+
+    def prepare_node_text(
+        self, name: str, node_type: str, date_range: str = "", description: str = ""
+    ) -> str:
+        """
+        Prepare text for embedding by concatenating node properties.
+        Truncates the description to avoid exceeding token limits.
+
+        Args:
+            name: Node name
+            node_type: Node type
+            date_range: Date range string
+            description: Full description (will be truncated if needed)
+
+        Returns:
+            Concatenated text ready for embedding
+        """
+        # Simple truncation strategy - could be improved with smarter tokenization
+        main_text = f"{name} {node_type} {date_range}".strip()
+        remaining_length = TRUNCATE_DESCRIPTION_LENGTH - len(main_text.split())
+
+        # Simple word-based truncation (approximation)
+        if description:
+            desc_words = description.split()
+            if len(desc_words) > remaining_length:
+                description = " ".join(desc_words[:remaining_length])
+
+        return f"{main_text} {description}".strip()
+
+
+def export_quantized_model(
+    output_dir: str = str(DEFAULT_QUANTIZED_DIR),
+    model_name: str = DEFAULT_MODEL_NAME,
+    quantization_config: str = DEFAULT_QUANTIZATION,
+) -> str:
+    """
+    Export a dynamically quantized ONNX model.
+
+    Args:
+        output_dir: Directory to save the quantized model
+        model_name: Name of the model to quantize
+        quantization_config: Configuration for quantization, auto-determined if None
+
+    Returns:
+        Path to the exported model
+    """
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    # Load the model with ONNX backend
+    model = SentenceTransformer(model_name, backend="onnx")
+
+    # Export the quantized model with the config
+    export_dynamic_quantized_onnx_model(
+        model=model,
+        model_name_or_path=output_dir,
+        quantization_config=quantization_config,
+    )
+
+    return output_dir
+
+
+# Create a singleton instance
+model_manager = ModelManager()

--- a/src/chronicler_backend/utils/embeddings.py
+++ b/src/chronicler_backend/utils/embeddings.py
@@ -17,6 +17,9 @@ from chronicler_backend.utils.constants import (
     DEFAULT_QUANTIZED_DIR,
     TRUNCATE_DESCRIPTION_LENGTH,
 )
+from chronicler_backend.utils.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class ModelManager:
@@ -24,6 +27,9 @@ class ModelManager:
     Singleton manager for sentence transformer models that supports
     efficient memory usage across multiple FastAPI workers.
     """
+
+    def __init__(self) -> None:
+        self._model: Optional[SentenceTransformer] = None
 
     def load_model(
         self, model_path: Optional[str] = None, quantized: bool = True, backend: str = "onnx"
@@ -42,7 +48,27 @@ class ModelManager:
         if model_path is None:
             model_path = str(DEFAULT_QUANTIZED_DIR if quantized else DEFAULT_MODEL_NAME)
 
-        self._model = SentenceTransformer(model_path, backend=backend)
+        try:
+            # For ONNX models, we need to specify the file path relative to the model directory
+            if quantized and backend == "onnx":
+                # Point to the exact ONNX file in the onnx subdirectory
+                model_kwargs = {
+                    "file_name": "onnx/model_quint8_avx2.onnx",
+                    "provider": "CPUExecutionProvider",
+                }
+                self._model = SentenceTransformer(
+                    model_path, backend=backend, model_kwargs=model_kwargs
+                )
+                logger.info(f"Loaded quantized model from {model_path}")
+            else:
+                self._model = SentenceTransformer(model_path, backend=backend)
+                logger.info(f"Loaded standard model ({backend = }) from {model_path}")
+        except Exception as e:
+            # Log the error and fall back to the non-quantized model
+            logger.error(
+                f"Error loading model with {backend = }: {e}. Falling back to standard model."
+            )
+            self._model = SentenceTransformer(DEFAULT_MODEL_NAME)
 
     def get_model(self) -> SentenceTransformer:
         """Get the loaded model or load it if not already loaded."""
@@ -111,17 +137,33 @@ def export_quantized_model(
     output_path = Path(output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
 
-    # Load the model with ONNX backend
-    model = SentenceTransformer(model_name, backend="onnx")
+    # 1. First load the model with standard PyTorch backend
+    model = SentenceTransformer(model_name)
 
-    # Export the quantized model with the config
-    export_dynamic_quantized_onnx_model(
-        model=model,
-        model_name_or_path=output_dir,
-        quantization_config=quantization_config,
-    )
+    # 2. Save the base model files to the output directory
+    model.save(output_dir)
 
-    return output_dir
+    # 3. Now load with ONNX backend and export the quantized model
+    try:
+        onnx_model = SentenceTransformer(model_name, backend="onnx")
+
+        # Export the quantized model directly to the output directory
+        export_dynamic_quantized_onnx_model(
+            model=onnx_model,
+            model_name_or_path=output_dir,
+            quantization_config=quantization_config,
+        )
+
+        # Verify the export was successful
+        logger.info(f"Successfully exported quantized model to {output_dir}")
+        for item in output_path.glob("**/*"):
+            logger.debug(f"  {item}")
+
+        return output_dir
+    except Exception as e:
+        logger.error(f"Error exporting quantized model: {e}")
+        # Make sure to return the original model path for fallback
+        return output_dir
 
 
 # Create an instance of ModelManager

--- a/src/chronicler_backend/utils/logging.py
+++ b/src/chronicler_backend/utils/logging.py
@@ -49,7 +49,7 @@ def _setup_logging(
     log_level_name = os.getenv(env_key_level)
     if log_level_name:
         try:
-            log_level = getattr(logging, log_level_name.upper())
+            log_level = getattr(logging, log_level_name.upper().strip())
         except AttributeError:
             # Fall back to default if invalid level name
             log_level = default_level

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@
 These fixtures are shared among all tests.
 """
 
-import logging
 import os
 from typing import Generator
 
@@ -10,8 +9,9 @@ import pytest
 from neo4j.exceptions import ServiceUnavailable
 
 from chronicler_backend.db.neo4j import Neo4jDatabase
+from chronicler_backend.utils.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 @pytest.fixture(scope="module")

--- a/tests/medium/conftest.py
+++ b/tests/medium/conftest.py
@@ -1,0 +1,46 @@
+"""
+These fixtures are shared among medium-sized tests.
+Unlike small tests, these may connect to real databases and services.
+"""
+
+import pytest
+
+from chronicler_backend.db.node import NodeDatabase
+from chronicler_backend.embeddings.api import get_model_manager
+from chronicler_backend.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+@pytest.fixture(scope="function")
+async def model_manager():
+    """
+    Create model manager instance for testing.
+
+    Unlike small tests, this uses the actual model for embedding generation.
+
+    Returns:
+        ModelManager: Model manager instance
+    """
+    manager = await get_model_manager()
+    manager.load_model(quantized=True, backend="onnx", verbose=True)
+    return manager
+
+
+@pytest.fixture(scope="module")
+def node_db(neo4j_db):
+    """
+    Create a NodeDatabase instance for testing.
+
+    Args:
+        neo4j_db: Neo4j database instance
+
+    Returns:
+        NodeDatabase: Node database instance
+    """
+    db = NodeDatabase(neo4j_db)
+
+    # Set up vector index
+    assert db.setup_vector_index() is True
+
+    return db

--- a/tests/medium/test_graphql_schema_execution.py
+++ b/tests/medium/test_graphql_schema_execution.py
@@ -1,0 +1,417 @@
+"""
+Medium-sized tests that utilize schema.execute_sync() for API functionality testing.
+
+These tests execute GraphQL queries and mutations directly against the schema
+without mocking the resolvers, providing more comprehensive integration testing.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from chronicler_backend.graphql.schema import schema
+from chronicler_backend.models.node import DateRange, Node, NodeType
+from chronicler_backend.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class TestGraphQLSchemaExecution:
+    """Test class for executing GraphQL operations through the schema."""
+
+    @pytest.mark.asyncio
+    async def test_create_and_query_node(self, neo4j_db, node_db):
+        """Test creating a node via GraphQL and then querying it."""
+        # Define a GraphQL mutation to create a node
+        create_mutation = """
+        mutation CreateTestNode($input: NodeInput!) {
+            createNode(input: $input) {
+                uuid
+                name
+                nodeType
+                description
+                dateRange {
+                    start
+                    end
+                }
+                hierarchyRank
+            }
+        }
+        """
+
+        # Define the input variables
+        node_input = {
+            "name": "Test GraphQL Node",
+            "nodeType": "EVENT",
+            "description": "This node was created through a GraphQL mutation",
+            "dateRange": {"start": "2020-01-01T00:00:00", "end": "2020-12-31T23:59:59"},
+        }
+
+        # Execute the mutation
+        # Fix: Use root_value with context key instead of context parameter
+        result = await schema.execute(
+            create_mutation, variable_values={"input": node_input}, context_value={"db": neo4j_db}
+        )
+
+        # Check for errors
+        assert result.errors is None, f"GraphQL errors: {result.errors}"
+
+        # Verify the response data
+        assert result.data is not None
+        created_node = result.data["createNode"]
+        assert created_node["name"] == "Test GraphQL Node"
+        assert created_node["nodeType"] == "EVENT"
+        assert created_node["hierarchyRank"] == NodeType.EVENT.value
+
+        # Store the UUID for subsequent query
+        node_uuid = created_node["uuid"]
+
+        # Now query the node to verify it was created
+        query = """
+        query GetNode($uuid: String!) {
+            node(uuid: $uuid) {
+                uuid
+                name
+                nodeType
+                description
+                dateRange {
+                    start
+                    end
+                }
+            }
+        }
+        """
+
+        # Execute the query
+        result = await schema.execute(
+            query, variable_values={"uuid": node_uuid}, context_value={"db": neo4j_db}
+        )
+
+        # Check for errors
+        assert result.errors is None, f"GraphQL errors: {result.errors}"
+
+        # Verify the response data
+        assert result.data is not None
+        queried_node = result.data["node"]
+        assert queried_node["uuid"] == node_uuid
+        assert queried_node["name"] == "Test GraphQL Node"
+        assert queried_node["nodeType"] == "EVENT"
+
+        # Clean up - delete the node
+        try:
+            delete_mutation = """
+            mutation DeleteNode($uuid: String!) {
+                deleteNode(uuid: $uuid)
+            }
+            """
+            result = await schema.execute(
+                delete_mutation, variable_values={"uuid": node_uuid}, context_value={"db": neo4j_db}
+            )
+            assert result.errors is None
+            assert result.data["deleteNode"] is True
+        except Exception as e:
+            logger.error(f"Error cleaning up test node: {e}")
+            # Fallback cleanup using NodeDatabase
+            node_db.delete_node(node_uuid)
+
+    @pytest.mark.asyncio
+    async def test_semantic_search_via_graphql(self, neo4j_db, node_db):
+        """Test semantic search via GraphQL API."""
+        # Create test nodes first
+        nodes = [
+            Node(
+                name="French Revolution",
+                node_type=NodeType.EVENT,
+                description=(
+                    "A period of radical social and political upheaval "
+                    "in France from 1789 to 1799."
+                ),
+                date_range=DateRange(start=datetime(1789, 7, 14), end=datetime(1799, 11, 9)),
+            ),
+            Node(
+                name="Roman Empire",
+                node_type=NodeType.CIVILIZATION,
+                description=(
+                    "Ancient civilization centered around the city of Rome,"
+                    " spanning from 27 BC to 476 AD."
+                ),
+                date_range=DateRange(start=datetime(27, 1, 1, 0, 0, 0), end=datetime(476, 9, 4)),
+            ),
+            Node(
+                name="Industrial Revolution",
+                node_type=NodeType.ERA,
+                description=(
+                    "Transition to new manufacturing processes in "
+                    "Europe and the United States, from 1760 to 1840."
+                ),
+                date_range=DateRange(start=datetime(1760, 1, 1), end=datetime(1840, 12, 31)),
+            ),
+        ]
+
+        created_nodes = []
+        for node in nodes:
+            created_node = await node_db.create_node(node)
+            created_nodes.append(created_node)
+
+        try:
+            # Query using the searchNodesByText operation
+            search_query = """
+            query SearchNodes($searchText: String!, $limit: Int!) {
+                searchNodesByText(searchText: $searchText, limit: $limit) {
+                    uuid
+                    name
+                    nodeType
+                    description
+                }
+            }
+            """
+
+            # Search for content related to "ancient Rome"
+            result = await schema.execute(
+                search_query,
+                variable_values={"searchText": "ancient Rome civilization", "limit": 1},
+                context_value={"db": neo4j_db},
+            )
+
+            # Check for errors
+            assert result.errors is None, f"GraphQL errors: {result.errors}"
+
+            # Verify Roman Empire is in the results
+            search_results = result.data["searchNodesByText"]
+            assert any(
+                node["name"] == "Roman Empire" for node in search_results
+            ), "Roman Empire should be in search results"
+
+            # Search for revolutions and verify both French and Industrial Revolutions are found
+            result = await schema.execute(
+                search_query,
+                variable_values={"searchText": "revolution political changes", "limit": 2},
+                context_value={"db": neo4j_db},
+            )
+
+            # Check for errors
+            assert result.errors is None, f"GraphQL errors: {result.errors}"
+
+            # Verify both revolution nodes are in the results
+            search_results = result.data["searchNodesByText"]
+            found_french = any(node["name"] == "French Revolution" for node in search_results)
+            found_industrial = any(
+                node["name"] == "Industrial Revolution" for node in search_results
+            )
+
+            # At least one of them should be found
+            # (ideally both, but semantic search is probabilistic)
+            assert (
+                found_french and found_industrial
+            ), "At least one revolution node should be in search results"
+
+        finally:
+            # Clean up - delete test nodes
+            for node in created_nodes:
+                node_db.delete_node(node.uuid)
+
+    @pytest.mark.asyncio
+    async def test_create_and_query_relationship(self, neo4j_db, node_db):
+        """Test creating a relationship via GraphQL and then querying it via node_neighbors."""
+        # Create two nodes first through the GraphQL API
+        create_mutation = """
+        mutation CreateNode($input: NodeInput!) {
+            createNode(input: $input) {
+                uuid
+                name
+            }
+        }
+        """
+
+        # Create parent node
+        country_input = {
+            "name": "Great Britain",
+            "nodeType": "COUNTRY",
+            "description": "Island nation in northwestern Europe",
+        }
+
+        result = await schema.execute(
+            create_mutation,
+            variable_values={"input": country_input},
+            context_value={"db": neo4j_db},
+        )
+
+        assert result.errors is None
+        country_uuid = result.data["createNode"]["uuid"]
+
+        # Create child node
+        city_input = {
+            "name": "London",
+            "nodeType": "CITY",
+            "description": "Capital city of Great Britain",
+        }
+
+        result = await schema.execute(
+            create_mutation, variable_values={"input": city_input}, context_value={"db": neo4j_db}
+        )
+
+        assert result.errors is None
+        city_uuid = result.data["createNode"]["uuid"]
+
+        try:
+            # Create relationship
+            create_relationship_mutation = """
+            mutation CreateRelationship(
+                $fromUuid: String!,
+                $toUuid: String!,
+                $relType: RelationshipType!
+            ) {
+                createRelationship(
+                    fromUuid: $fromUuid,
+                    toUuid: $toUuid,
+                    relationshipType: $relType
+                )
+            }
+            """
+
+            result = await schema.execute(
+                create_relationship_mutation,
+                variable_values={
+                    "fromUuid": country_uuid,
+                    "toUuid": city_uuid,
+                    "relType": "CONTAINS",
+                },
+                context_value={"db": neo4j_db},
+            )
+
+            assert result.errors is None
+            assert result.data["createRelationship"] is True
+
+            # Query relationship through nodeNeighbors
+            query = """
+            query GetNeighbors($uuid: String!, $sameTypeOnly: Boolean!) {
+                nodeNeighbors(uuid: $uuid, sameTypeOnly: $sameTypeOnly) {
+                    uuid
+                    name
+                    nodeType
+                    description
+                }
+            }
+            """
+
+            result = await schema.execute(
+                query,
+                variable_values={"uuid": country_uuid, "sameTypeOnly": False},
+                context_value={"db": neo4j_db},
+            )
+
+            assert result.errors is None
+            neighbors = result.data["nodeNeighbors"]
+            assert len(neighbors) == 1
+            assert neighbors[0]["uuid"] == city_uuid
+            assert neighbors[0]["name"] == "London"
+
+            # Query with rank filter
+            rank_query = """
+            query GetNeighborsWithRankFilter($uuid: String!, $rankFilter: RankFilterType!) {
+                nodeNeighbors(uuid: $uuid, rankFilter: $rankFilter) {
+                    uuid
+                    name
+                    nodeType
+                }
+            }
+            """
+
+            result = await schema.execute(
+                rank_query,
+                variable_values={"uuid": country_uuid, "rankFilter": "LOWER"},
+                context_value={"db": neo4j_db},
+            )
+
+            # Check country has lower rank neighbor (city)
+            assert result.errors is None
+            neighbors = result.data["nodeNeighbors"]
+            assert len(neighbors) == 1
+            assert neighbors[0]["uuid"] == city_uuid
+            assert neighbors[0]["nodeType"] == "CITY"
+
+        finally:
+            # Clean up - delete nodes
+            node_db.delete_node(country_uuid)
+            node_db.delete_node(city_uuid)
+
+    @pytest.mark.asyncio
+    async def test_update_node_via_graphql(self, neo4j_db, node_db):
+        """Test updating a node via GraphQL."""
+        # Create a node first
+        node = Node(
+            name="Original Node",
+            node_type=NodeType.PERIOD,  # Changed from PERSON to PERIOD (an existing enum value)
+            description="Original description",
+            date_range=DateRange(start=datetime(1900, 1, 1), end=datetime(1970, 12, 31)),
+        )
+
+        created_node = await node_db.create_node(node)
+        node_uuid = created_node.uuid
+
+        try:
+            # Update the node via GraphQL
+            update_mutation = """
+            mutation UpdateNode($uuid: String!, $input: NodeInput!) {
+                updateNode(uuid: $uuid, input: $input) {
+                    uuid
+                    name
+                    nodeType
+                    description
+                    dateRange {
+                        start
+                        end
+                    }
+                }
+            }
+            """
+
+            update_input = {
+                "name": "Updated Node",
+                "nodeType": "PERIOD",
+                "description": "Updated description with more details",
+                "dateRange": {"start": "1900-01-01T00:00:00", "end": "1980-12-31T23:59:59"},
+            }
+
+            result = await schema.execute(
+                update_mutation,
+                variable_values={"uuid": node_uuid, "input": update_input},
+                context_value={"db": neo4j_db},
+            )
+
+            # Check for errors
+            assert result.errors is None, f"GraphQL errors: {result.errors}"
+
+            # Verify update was successful
+            updated = result.data["updateNode"]
+            assert updated["name"] == "Updated Node"
+            assert updated["description"] == "Updated description with more details"
+            assert "1980" in updated["dateRange"]["end"]
+
+            # Query to verify persistence
+            query = """
+            query GetNode($uuid: String!) {
+                node(uuid: $uuid) {
+                    name
+                    description
+                    dateRange {
+                        end
+                    }
+                }
+            }
+            """
+
+            result = await schema.execute(
+                query, variable_values={"uuid": node_uuid}, context_value={"db": neo4j_db}
+            )
+
+            # Verify the node was updated in the database
+            assert result.errors is None
+            queried = result.data["node"]
+            assert queried["name"] == "Updated Node"
+            assert queried["description"] == "Updated description with more details"
+            assert "1980" in queried["dateRange"]["end"]
+
+        finally:
+            # Clean up
+            node_db.delete_node(node_uuid)

--- a/tests/medium/test_node_vector_embeddings.py
+++ b/tests/medium/test_node_vector_embeddings.py
@@ -1,0 +1,193 @@
+"""
+Medium-sized tests validating node creation with vector embeddings and semantic querying.
+
+These tests use actual model inference and Neo4j connections.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from chronicler_backend.models.node import DateRange, Node, NodeType
+from chronicler_backend.utils.constants import VECTOR_DIMENSION
+from chronicler_backend.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+@pytest.mark.asyncio
+async def test_create_node_with_embedded_description(node_db):
+    """Test creating nodes with vector embeddings generated from descriptions."""
+    # Create a node with a rich description
+    world_war_node = Node(
+        name="World War II",
+        node_type=NodeType.WAR,
+        description=(
+            "Global conflict from 1939-1945 involving most nations"
+            " including the US, USSR, UK, and Germany. "
+            "It was the most widespread war in history"
+            " with fighting in Europe, Pacific, and Africa."
+        ),
+        date_range=DateRange(start=datetime(1939, 9, 1), end=datetime(1945, 9, 2)),
+    )
+
+    # Create node without manually providing a vector embedding
+    created_node = await node_db.create_node(world_war_node)
+
+    # Verify the node was created
+    assert created_node is not None
+    assert created_node.uuid == world_war_node.uuid
+
+    # Verify that a vector embedding was automatically generated
+    assert created_node.vector_embedding is not None
+    assert len(created_node.vector_embedding) == VECTOR_DIMENSION
+
+    # All vectors should be float values between -1 and 1
+    assert all(-1 <= x <= 1 for x in created_node.vector_embedding)
+
+    return created_node
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_related_wars(node_db, model_manager):
+    """Test semantic search by finding related wars."""
+    # Create multiple war nodes with different descriptions
+    ww2_node = Node(
+        name="World War II",
+        node_type=NodeType.WAR,
+        description=(
+            "Global conflict from 1939-1945 involving most nations "
+            "including the US, USSR, UK, and Germany. "
+            "It was the most widespread war in history with fighting"
+            " in Europe, Pacific, and Africa."
+        ),
+        date_range=DateRange(start=datetime(1939, 9, 1), end=datetime(1945, 9, 2)),
+    )
+
+    civil_war_node = Node(
+        name="American Civil War",
+        node_type=NodeType.WAR,
+        description=(
+            "War fought in the United States from 1861 to 1865 "
+            "between the Union and the Confederacy "
+            "over slavery and states' rights."
+        ),
+        date_range=DateRange(start=datetime(1861, 4, 12), end=datetime(1865, 5, 9)),
+    )
+
+    vietnam_war_node = Node(
+        name="Vietnam War",
+        node_type=NodeType.WAR,
+        description=(
+            "Cold War-era conflict in Vietnam, Laos, and Cambodia"
+            " from 1954 to 1975 between North Vietnam "
+            "and South Vietnam, with the US supporting South Vietnam."
+        ),
+        date_range=DateRange(start=datetime(1954, 11, 1), end=datetime(1975, 4, 30)),
+    )
+
+    # Node with unrelated historical content
+    moon_landing_node = Node(
+        name="Apollo 11 Moon Landing",
+        node_type=NodeType.EVENT,
+        description=(
+            "NASA's mission in July 1969 that "
+            "landed the first humans on the Moon, "
+            "with Neil Armstrong and Buzz Aldrin."
+        ),
+        date_range=DateRange(start=datetime(1969, 7, 16), end=datetime(1969, 7, 24)),
+    )
+
+    # Create all nodes
+    created_nodes = []
+    for node in [ww2_node, civil_war_node, vietnam_war_node, moon_landing_node]:
+        created_node = await node_db.create_node(node)
+        assert created_node is not None
+        created_nodes.append(created_node)
+
+    try:
+        # Test 1: Search for content related to "global conflict involving many countries"
+        search_text = "global conflict involving many countries"
+        vector = model_manager.encode(search_text)
+        results = node_db.search_nodes_by_vector_similarity(vector, limit=10)
+
+        # Should find WW2 as most relevant
+        assert any(n.name == "World War II" for n in results)
+        # Check that WW2 is more relevant than other nodes
+        ww2_index = next(i for i, n in enumerate(results) if n.name == "World War II")
+        assert ww2_index <= 1, "World War II should be one of the most relevant results"
+
+        # Test 2: Search for content related to "civil rights conflict"
+        search_text = "civil rights struggle in America"
+        vector = model_manager.encode(search_text)
+        results = node_db.search_nodes_by_vector_similarity(vector, limit=10)
+
+        # Should find Civil War as most relevant
+        assert any(n.name == "American Civil War" for n in results)
+        civil_war_index = next(i for i, n in enumerate(results) if n.name == "American Civil War")
+        assert civil_war_index <= 1, "American Civil War should be one of the most relevant results"
+
+        # Test 3: Search for content related to "space exploration"
+        search_text = "space exploration astronauts"
+        vector = model_manager.encode(search_text)
+        results = node_db.search_nodes_by_vector_similarity(vector, limit=10)
+
+        # Should find Moon Landing as most relevant
+        assert any(n.name == "Apollo 11 Moon Landing" for n in results)
+        moon_index = next(i for i, n in enumerate(results) if n.name == "Apollo 11 Moon Landing")
+        assert moon_index <= 1, "Moon Landing should be one of the most relevant results"
+
+    finally:
+        # Clean up - remove test nodes
+        for node in created_nodes:
+            node_db.delete_node(node.uuid)
+
+
+@pytest.mark.asyncio
+async def test_vector_update_on_description_change(node_db, model_manager):
+    """Test that changing a node's description updates its vector embedding."""
+    # Create a node with initial description
+    event_node = Node(
+        name="Battle of Gettysburg",
+        node_type=NodeType.BATTLE,
+        description="Major battle of the American Civil War",
+        date_range=DateRange(start=datetime(1863, 7, 1), end=datetime(1863, 7, 3)),
+    )
+
+    created_node = await node_db.create_node(event_node)
+    assert created_node is not None
+    original_vector = created_node.vector_embedding.copy()
+
+    try:
+        # Update the node with a more detailed description
+        updated_node = Node(
+            uuid=created_node.uuid,
+            name=created_node.name,
+            node_type=created_node.node_type,
+            description=(
+                "Major battle of the American Civil War fought in"
+                " Pennsylvania over three days in July 1863, "
+                "considered a turning point of the war with a decisive Union victory."
+            ),
+            date_range=created_node.date_range,
+        )
+
+        # Update the node and check that the vector has changed
+        result = await node_db.update_node(updated_node)
+        assert result is not None
+
+        # The vector should have changed
+        new_vector = result.vector_embedding
+        assert new_vector is not None
+        assert len(new_vector) == VECTOR_DIMENSION
+
+        # Calculate difference between vectors to confirm they changed
+        vector_diff = sum((a - b) ** 2 for a, b in zip(original_vector, new_vector))
+        assert vector_diff > 0.1, "Vector embedding should change when description changes"
+
+        # Verify original and new vectors are not the same
+        assert original_vector != new_vector
+
+    finally:
+        # Clean up
+        node_db.delete_node(created_node.uuid)

--- a/tests/small/conftest.py
+++ b/tests/small/conftest.py
@@ -25,7 +25,7 @@ def mock_generate_vector_embedding(mocker):
     # Mock the actual method on the class itself
     original_method = NodeDatabase._generate_vector_embedding
 
-    def mock_generate_vector(*args, **kwargs):
+    async def mock_generate_vector(*args, **kwargs):
         logger.debug("Using mocked vector embedding generator")
         return default_vector
 

--- a/tests/small/conftest.py
+++ b/tests/small/conftest.py
@@ -1,0 +1,38 @@
+import pytest
+
+from chronicler_backend.db.node import NodeDatabase
+from chronicler_backend.utils.constants import VECTOR_DIMENSION
+from chronicler_backend.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+@pytest.fixture(autouse=True)
+def mock_generate_vector_embedding(mocker):
+    """Automatically mock vector embedding generation to return a default vector.
+
+    This mocks the actual method in the NodeDatabase class, not the import path.
+
+    Args:
+        mocker: pytest's mocker fixture
+
+    Returns:
+        Mock object for the _generate_vector_embedding method
+    """
+    # Create a default vector of ones with the correct dimension
+    default_vector = [1.0] * VECTOR_DIMENSION
+
+    # Mock the actual method on the class itself
+    original_method = NodeDatabase._generate_vector_embedding
+
+    def mock_generate_vector(*args, **kwargs):
+        logger.debug("Using mocked vector embedding generator")
+        return default_vector
+
+    # Replace the method on the class
+    NodeDatabase._generate_vector_embedding = mock_generate_vector
+
+    yield
+
+    # Restore the original method after tests
+    NodeDatabase._generate_vector_embedding = original_method

--- a/tests/small/test_graphql_mutation.py
+++ b/tests/small/test_graphql_mutation.py
@@ -5,11 +5,11 @@ from datetime import datetime
 import pytest
 
 from chronicler_backend.graphql.mutation import DateRangeInput, Mutation, NodeInput
-from chronicler_backend.graphql.query import NodeType
+from chronicler_backend.graphql.query import NodeType, RelationshipType
 from chronicler_backend.models.node import DateRange as ModelDateRange
 from chronicler_backend.models.node import Node as ModelNode
 from chronicler_backend.models.node import NodeType as ModelNodeType
-from chronicler_backend.models.node import RelationshipType
+from chronicler_backend.models.node import RelationshipType as ModelRelationshipType
 from chronicler_backend.utils.constants import VECTOR_DIMENSION
 
 
@@ -295,10 +295,13 @@ def test_create_relationship(mocker):
         relationship_type=RelationshipType.PARTICIPATED_IN,
     )
 
-    # Verify the NodeDatabase was called correctly
-    mock_node_db.create_relationship.assert_called_once_with(
-        "source-uuid", "target-uuid", RelationshipType.PARTICIPATED_IN
-    )
+    # Verify the NodeDatabase was called correctly with the ModelRelationshipType
+    mock_node_db.create_relationship.assert_called_once()
+    args = mock_node_db.create_relationship.call_args[0]
+    assert args[0] == "source-uuid"
+    assert args[1] == "target-uuid"
+    assert isinstance(args[2], ModelRelationshipType)
+    assert args[2].value == "PARTICIPATED_IN"
 
     # Verify result is True (relationship created)
     assert result is True
@@ -328,7 +331,7 @@ def test_create_relationship_failure(mocker):
         mock_info,
         from_uuid="invalid-uuid",
         to_uuid="invalid-uuid-2",
-        relationship_type=RelationshipType.FOLLOWS,  # Using a valid enum value
+        relationship_type=RelationshipType.FOLLOWS,
     )
 
     # Verify result is False (failed to create relationship)

--- a/tests/small/test_graphql_mutation.py
+++ b/tests/small/test_graphql_mutation.py
@@ -9,6 +9,7 @@ from chronicler_backend.graphql.query import NodeType
 from chronicler_backend.models.node import DateRange as ModelDateRange
 from chronicler_backend.models.node import Node as ModelNode
 from chronicler_backend.models.node import NodeType as ModelNodeType
+from chronicler_backend.models.node import RelationshipType
 from chronicler_backend.utils.constants import VECTOR_DIMENSION
 
 
@@ -275,6 +276,13 @@ def test_create_relationship(mocker):
     # Configure the mock to return a success result for run_query
     mock_db.run_query.return_value = {"created": 1}
 
+    # Create mock NodeDatabase
+    mock_node_db = mocker.MagicMock()
+    mock_node_db.create_relationship.return_value = True
+
+    # Mock NodeDatabase constructor
+    mocker.patch("chronicler_backend.graphql.mutation.NodeDatabase", return_value=mock_node_db)
+
     # Create mock info object
     mock_info = MockInfo(context={"db": mock_db})
 
@@ -284,17 +292,13 @@ def test_create_relationship(mocker):
         mock_info,
         from_uuid="source-uuid",
         to_uuid="target-uuid",
-        relationship_type="PARTICIPATED_IN",
+        relationship_type=RelationshipType.PARTICIPATED_IN,
     )
 
-    # Verify the database was called correctly
-    mock_db.run_query.assert_called_once()
-
-    # Check parameters passed to run_query
-    call_args = mock_db.run_query.call_args
-    assert "source-uuid" in str(call_args)
-    assert "target-uuid" in str(call_args)
-    assert "PARTICIPATED_IN" in str(call_args)
+    # Verify the NodeDatabase was called correctly
+    mock_node_db.create_relationship.assert_called_once_with(
+        "source-uuid", "target-uuid", RelationshipType.PARTICIPATED_IN
+    )
 
     # Verify result is True (relationship created)
     assert result is True
@@ -302,9 +306,15 @@ def test_create_relationship(mocker):
 
 def test_create_relationship_failure(mocker):
     """Test create_relationship mutation when creation fails."""
-    # Mock the database with an exception
+    # Mock the database
     mock_db = mocker.MagicMock()
-    mock_db.run_query.side_effect = Exception("Database error")
+
+    # Create mock NodeDatabase that raises an exception
+    mock_node_db = mocker.MagicMock()
+    mock_node_db.create_relationship.side_effect = Exception("Database error")
+
+    # Mock NodeDatabase constructor
+    mocker.patch("chronicler_backend.graphql.mutation.NodeDatabase", return_value=mock_node_db)
 
     # Create mock info object
     mock_info = MockInfo(context={"db": mock_db})
@@ -318,7 +328,7 @@ def test_create_relationship_failure(mocker):
         mock_info,
         from_uuid="invalid-uuid",
         to_uuid="invalid-uuid-2",
-        relationship_type="INVALID_TYPE",
+        relationship_type=RelationshipType.FOLLOWS,  # Using a valid enum value
     )
 
     # Verify result is False (failed to create relationship)

--- a/tests/small/test_graphql_mutation.py
+++ b/tests/small/test_graphql_mutation.py
@@ -9,6 +9,7 @@ from chronicler_backend.graphql.query import NodeType
 from chronicler_backend.models.node import DateRange as ModelDateRange
 from chronicler_backend.models.node import Node as ModelNode
 from chronicler_backend.models.node import NodeType as ModelNodeType
+from chronicler_backend.utils.constants import VECTOR_DIMENSION
 
 
 class MockInfo:
@@ -81,9 +82,7 @@ def test_create_node_with_vector(mocker, mock_uuid):
     # Mock the NodeDatabase instance
     mock_node_db = mocker.MagicMock()
 
-    # Setup test vector - match VECTOR_DIMENSION from constants
-    vector_dimension = 1536
-    test_vector = [0.1] * vector_dimension
+    test_vector = [0.1] * VECTOR_DIMENSION
 
     # Setup the mock to return a node on creation
     created_model_node = ModelNode(
@@ -354,7 +353,7 @@ def test_create_node_invalid_vector_dimension(mocker):
 
     # Verify error message mentions vector dimension
     assert "Vector embedding must have exactly" in str(excinfo.value)
-    assert "1536" in str(excinfo.value)
+    assert f"{VECTOR_DIMENSION}" in str(excinfo.value)
 
     # Verify create_node was not called
     mock_node_db.create_node.assert_not_called()

--- a/tests/small/test_graphql_mutation.py
+++ b/tests/small/test_graphql_mutation.py
@@ -26,10 +26,11 @@ def mock_uuid() -> str:
     return "12345678-1234-5678-1234-567812345678"
 
 
-def test_create_node(mocker, mock_uuid):
+@pytest.mark.asyncio
+async def test_create_node(mocker, mock_uuid):
     """Test create_node mutation."""
     # Mock the NodeDatabase instance
-    mock_node_db = mocker.MagicMock()
+    mock_node_db = mocker.AsyncMock()
 
     # Setup the mock to return a node on creation
     created_model_node = ModelNode(
@@ -61,7 +62,7 @@ def test_create_node(mocker, mock_uuid):
 
     # Execute the mutation
     mutation = Mutation()
-    result = mutation.create_node(mock_info, node_input)
+    result = await mutation.create_node(mock_info, node_input)
 
     # Verify the database was called correctly
     mock_node_db.create_node.assert_called_once()
@@ -78,10 +79,11 @@ def test_create_node(mocker, mock_uuid):
     assert result.date_range.end == datetime(2021, 1, 1)
 
 
-def test_create_node_with_vector(mocker, mock_uuid):
+@pytest.mark.asyncio
+async def test_create_node_with_vector(mocker, mock_uuid):
     """Test create_node mutation with vector embedding."""
     # Mock the NodeDatabase instance
-    mock_node_db = mocker.MagicMock()
+    mock_node_db = mocker.AsyncMock()
 
     test_vector = [0.1] * VECTOR_DIMENSION
 
@@ -112,7 +114,7 @@ def test_create_node_with_vector(mocker, mock_uuid):
 
     # Execute the mutation
     mutation = Mutation()
-    result = mutation.create_node(mock_info, node_input)
+    result = await mutation.create_node(mock_info, node_input)
 
     # Verify the database was called correctly
     mock_node_db.create_node.assert_called_once()
@@ -123,10 +125,12 @@ def test_create_node_with_vector(mocker, mock_uuid):
     assert result.node_type == NodeType.BATTLE
 
 
-def test_update_node(mocker):
+@pytest.mark.asyncio
+async def test_update_node(mocker):
     """Test update_node mutation."""
     # Mock the NodeDatabase instance
     mock_node_db = mocker.MagicMock()
+    mock_node_db.update_node = mocker.AsyncMock()
 
     # Setup the mock to return a node on update
     updated_model_node = ModelNode(
@@ -144,6 +148,7 @@ def test_update_node(mocker):
         name="Original Node",
         node_type=ModelNodeType.EVENT,
         description="Original description",
+        vector_embedding=[0.1] * VECTOR_DIMENSION,
     )
     mock_node_db.get_node.return_value = existing_node
 
@@ -165,7 +170,7 @@ def test_update_node(mocker):
 
     # Execute the mutation
     mutation = Mutation()
-    result = mutation.update_node(mock_info, uuid="existing-uuid", input=node_input)
+    result = await mutation.update_node(mock_info, uuid="existing-uuid", input=node_input)
 
     # Verify the database was called correctly
     mock_node_db.get_node.assert_called_once_with("existing-uuid")
@@ -182,10 +187,12 @@ def test_update_node(mocker):
     assert result.date_range.end == datetime(2022, 1, 1)
 
 
-def test_update_node_not_found(mocker):
+@pytest.mark.asyncio
+async def test_update_node_not_found(mocker):
     """Test update_node when the node doesn't exist."""
     # Mock the NodeDatabase instance
     mock_node_db = mocker.MagicMock()
+    mock_node_db.update_node = mocker.AsyncMock()
 
     # Configure mock to return None (node not found)
     mock_node_db.get_node.return_value = None
@@ -206,7 +213,7 @@ def test_update_node_not_found(mocker):
 
     # Execute the mutation
     mutation = Mutation()
-    result = mutation.update_node(mock_info, uuid="nonexistent-uuid", input=node_input)
+    result = await mutation.update_node(mock_info, uuid="nonexistent-uuid", input=node_input)
 
     # Verify get_node was called but update_node was not
     mock_node_db.get_node.assert_called_once_with("nonexistent-uuid")
@@ -214,6 +221,41 @@ def test_update_node_not_found(mocker):
 
     # Result should be None for non-existent node
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_create_node_invalid_vector_dimension(mocker):
+    """Test create_node mutation with invalid vector dimension."""
+    # Mock the NodeDatabase instance
+    mock_node_db = mocker.AsyncMock()
+
+    # Create mock db and info
+    mock_db = mocker.MagicMock()
+    mock_info = MockInfo(context={"db": mock_db})
+
+    # Mock NodeDatabase constructor
+    mocker.patch("chronicler_backend.graphql.mutation.NodeDatabase", return_value=mock_node_db)
+
+    # Create test input with an invalid vector dimension
+    invalid_vector = [0.1] * 10  # Should be VECTOR_DIMENSION
+    node_input = NodeInput(
+        name="Invalid Vector Node",
+        node_type=NodeType.EVENT,
+        description="Node with invalid vector",
+        vector_embedding=invalid_vector,
+    )
+
+    # Execute the mutation and expect ValueError
+    mutation = Mutation()
+    with pytest.raises(ValueError) as excinfo:
+        await mutation.create_node(mock_info, node_input)
+
+    # Verify error message mentions vector dimension
+    assert "Vector embedding must have exactly" in str(excinfo.value)
+    assert f"{VECTOR_DIMENSION}" in str(excinfo.value)
+
+    # Verify create_node was not called
+    mock_node_db.create_node.assert_not_called()
 
 
 def test_delete_node(mocker):
@@ -336,37 +378,3 @@ def test_create_relationship_failure(mocker):
 
     # Verify result is False (failed to create relationship)
     assert result is False
-
-
-def test_create_node_invalid_vector_dimension(mocker):
-    """Test create_node mutation with invalid vector dimension."""
-    # Mock the NodeDatabase instance
-    mock_node_db = mocker.MagicMock()
-
-    # Create mock db and info
-    mock_db = mocker.MagicMock()
-    mock_info = MockInfo(context={"db": mock_db})
-
-    # Mock NodeDatabase constructor
-    mocker.patch("chronicler_backend.graphql.mutation.NodeDatabase", return_value=mock_node_db)
-
-    # Create test input with an invalid vector dimension
-    invalid_vector = [0.1] * 10  # Should be VECTOR_DIMENSION
-    node_input = NodeInput(
-        name="Invalid Vector Node",
-        node_type=NodeType.EVENT,
-        description="Node with invalid vector",
-        vector_embedding=invalid_vector,
-    )
-
-    # Execute the mutation and expect ValueError
-    mutation = Mutation()
-    with pytest.raises(ValueError) as excinfo:
-        mutation.create_node(mock_info, node_input)
-
-    # Verify error message mentions vector dimension
-    assert "Vector embedding must have exactly" in str(excinfo.value)
-    assert f"{VECTOR_DIMENSION}" in str(excinfo.value)
-
-    # Verify create_node was not called
-    mock_node_db.create_node.assert_not_called()

--- a/tests/small/test_graphql_mutation.py
+++ b/tests/small/test_graphql_mutation.py
@@ -339,7 +339,7 @@ def test_create_node_invalid_vector_dimension(mocker):
     mocker.patch("chronicler_backend.graphql.mutation.NodeDatabase", return_value=mock_node_db)
 
     # Create test input with an invalid vector dimension
-    invalid_vector = [0.1] * 10  # Should be VECTOR_DIMENSION (1536)
+    invalid_vector = [0.1] * 10  # Should be VECTOR_DIMENSION
     node_input = NodeInput(
         name="Invalid Vector Node",
         node_type=NodeType.EVENT,

--- a/tests/small/test_graphql_query.py
+++ b/tests/small/test_graphql_query.py
@@ -193,7 +193,7 @@ def test_query_node_neighbors(mocker):
 
     # Verify that NodeDatabase.get_node_neighbors was called with the correct params
     mock_node_db.get_node_neighbors.assert_called_once_with(
-        "test-uuid", same_type_only=True, limit=5, offset=0
+        "test-uuid", same_type_only=True, rank_filter=None, limit=5, offset=0
     )
 
     # Verify the returned GraphQL nodes match our model nodes
@@ -204,6 +204,46 @@ def test_query_node_neighbors(mocker):
         assert node.node_type == NodeType.BATTLE
         assert node.description == f"Neighbor Description {i}"
         assert node.hierarchy_rank == ModelNodeType.BATTLE.value
+
+    # Reset mock for the next test
+    mock_node_db.reset_mock()
+
+    # Configure mock for rank filter test
+    lower_rank_neighbors = [
+        ModelNode(
+            uuid="city-node",
+            name="City Node",
+            node_type=ModelNodeType.CITY,
+            description="A city node with lower rank",
+        )
+    ]
+    mock_node_db.get_node_neighbors.return_value = lower_rank_neighbors
+
+    # Import the RankFilterType enum
+    from chronicler_backend.graphql.query import RankFilterType
+
+    # Test with rank filter
+    result_with_rank_filter = query.node_neighbors(
+        mock_info,
+        uuid="test-uuid",
+        same_type_only=False,
+        rank_filter=RankFilterType.LOWER,
+        limit=5,
+        offset=0,
+    )
+
+    # Verify the correct parameters were passed with rank filter value
+    mock_node_db.get_node_neighbors.assert_called_once_with(
+        "test-uuid", same_type_only=False, rank_filter="lower", limit=5, offset=0
+    )
+
+    # Verify the returned GraphQL nodes match our model nodes for rank filter
+    assert len(result_with_rank_filter) == 1
+    assert result_with_rank_filter[0].uuid == "city-node"
+    assert result_with_rank_filter[0].name == "City Node"
+    assert result_with_rank_filter[0].node_type == NodeType.CITY
+    assert result_with_rank_filter[0].description == "A city node with lower rank"
+    assert result_with_rank_filter[0].hierarchy_rank == ModelNodeType.CITY.value
 
 
 def test_query_nodes_by_date_range(mocker):

--- a/tests/small/test_neo4j.py
+++ b/tests/small/test_neo4j.py
@@ -1,8 +1,0 @@
-"""Unit tests for Neo4j database integration."""
-
-
-def test_connection(neo4j_db):
-    """Test Neo4j connection."""
-    # Use return_single parameter to get the result directly
-    result = neo4j_db.run_query("RETURN 1 AS one", return_single=True)
-    assert result["one"] == 1

--- a/tests/small/test_node_crud.py
+++ b/tests/small/test_node_crud.py
@@ -226,7 +226,8 @@ def test_vector_index_and_similarity_search(neo4j_db):
         description="Civil war fought in the United States from 1861 to 1865",
         date_range=DateRange(start=datetime(1861, 4, 12), end=datetime(1865, 5, 9)),
         # Simple test vector - mostly 1s in first half, 0s in second half
-        vector_embedding=[1.0] * (VECTOR_DIMENSION // 2) + [0.0] * (VECTOR_DIMENSION // 2),
+        vector_embedding=[1.0] * (VECTOR_DIMENSION // 2)
+        + [0.0] * (VECTOR_DIMENSION - VECTOR_DIMENSION // 2),
     )
     created_history = node_db.create_node(history_node)
     assert created_history is not None
@@ -238,7 +239,8 @@ def test_vector_index_and_similarity_search(neo4j_db):
         description="Major battle of the American Civil War",
         date_range=DateRange(start=datetime(1863, 7, 1), end=datetime(1863, 7, 3)),
         # Similar vector - mostly 1s in first half, small values in second half
-        vector_embedding=[1.0] * (VECTOR_DIMENSION // 2) + [0.1] * (VECTOR_DIMENSION // 2),
+        vector_embedding=[1.0] * (VECTOR_DIMENSION // 2)
+        + [0.1] * (VECTOR_DIMENSION - VECTOR_DIMENSION // 2),
     )
     created_similar = node_db.create_node(similar_history_node)
     assert created_similar is not None
@@ -250,14 +252,17 @@ def test_vector_index_and_similarity_search(neo4j_db):
         description="Major scientific breakthrough",
         date_range=DateRange(start=datetime(1945, 1, 1), end=datetime(1945, 12, 31)),
         # Different vector - 0s in first half, 1s in second half
-        vector_embedding=[0.0] * (VECTOR_DIMENSION // 2) + [1.0] * (VECTOR_DIMENSION // 2),
+        vector_embedding=[0.0] * (VECTOR_DIMENSION // 2)
+        + [1.0] * (VECTOR_DIMENSION - VECTOR_DIMENSION // 2),
     )
     created_different = node_db.create_node(different_node)
     assert created_different is not None
 
     try:
         # Search with a vector similar to the history nodes
-        query_vector = [0.9] * (VECTOR_DIMENSION // 2) + [0.1] * (VECTOR_DIMENSION // 2)
+        query_vector = [0.9] * (VECTOR_DIMENSION // 2) + [0.1] * (
+            VECTOR_DIMENSION - VECTOR_DIMENSION // 2
+        )
         results = node_db.search_nodes_by_vector_similarity(query_vector, limit=3)
 
         # We should get at least 2 results

--- a/tests/small/test_node_crud.py
+++ b/tests/small/test_node_crud.py
@@ -7,6 +7,13 @@ from chronicler_backend.models.node import DateRange, Node, NodeType, Relationsh
 from chronicler_backend.utils.constants import VECTOR_DIMENSION
 
 
+def test_connection(neo4j_db):
+    """Test Neo4j connection."""
+    # Use return_single parameter to get the result directly
+    result = neo4j_db.run_query("RETURN 1 AS one", return_single=True)
+    assert result["one"] == 1
+
+
 def test_node_crud_operations(neo4j_db):
     """Test basic CRUD operations for nodes."""
     # Create a NodeDatabase instance

--- a/tests/small/test_node_crud.py
+++ b/tests/small/test_node_crud.py
@@ -70,6 +70,9 @@ def test_node_relationships(neo4j_db):
     )
     created_country = node_db.create_node(country)
 
+    country2 = Node(name="Canada", node_type=NodeType.COUNTRY, description="North American nation")
+    created_country2 = node_db.create_node(country2)
+
     # Create two child nodes (battles)
     battle1 = Node(
         name="Battle of Midway",
@@ -87,41 +90,81 @@ def test_node_relationships(neo4j_db):
     )
     created_battle2 = node_db.create_node(battle2)
 
+    # Create a city node (lower rank than country)
+    city = Node(
+        name="Washington D.C.",
+        node_type=NodeType.CITY,
+        description="Capital city of the United States",
+    )
+    created_city = node_db.create_node(city)
+
     # Create relationships using the new relationship type enum
+    assert node_db.create_relationship(
+        created_country.uuid, created_country2.uuid, RelationshipType.BORDERS
+    )
     assert node_db.create_relationship(
         created_country.uuid, created_battle1.uuid, RelationshipType.PARTICIPATED_IN
     )
     assert node_db.create_relationship(
         created_country.uuid, created_battle2.uuid, RelationshipType.PARTICIPATED_IN
     )
+    assert node_db.create_relationship(
+        created_country.uuid, created_city.uuid, RelationshipType.CONTAINS
+    )
 
     # Test getting relationships
     country_relationships = node_db.get_relationships(created_country.uuid, direction="OUTGOING")
-    assert len(country_relationships) == 2
+    assert len(country_relationships) == 4
 
     # Check relationship types
-    rel_types = [r["relationship_type"] for r in country_relationships]
-    assert all(rel_type == RelationshipType.PARTICIPATED_IN.value for rel_type in rel_types)
+    battle_rel_types = [
+        r["relationship_type"]
+        for r in country_relationships
+        if r["other_node_uuid"] in [created_battle1.uuid, created_battle2.uuid]
+    ]
+    assert all(rel_type == RelationshipType.PARTICIPATED_IN.value for rel_type in battle_rel_types)
 
-    # Check that related nodes are the battles
+    # Check that related nodes are the battles and city
     related_nodes = [r["other_node_uuid"] for r in country_relationships]
     assert created_battle1.uuid in related_nodes
     assert created_battle2.uuid in related_nodes
+    assert created_city.uuid in related_nodes
+    assert created_country2.uuid in related_nodes
 
-    # Get neighbors - should find both battles
+    # Get neighbors - should find both battles and the city
     neighbors = node_db.get_node_neighbors(created_country.uuid, same_type_only=False)
-    assert len(neighbors) == 2
+    assert len(neighbors) == 4
     neighbor_names = [n.name for n in neighbors]
     assert "Battle of Midway" in neighbor_names
     assert "D-Day" in neighbor_names
+    assert "Washington D.C." in neighbor_names
+    assert "Canada" in neighbor_names
 
-    # Get neighbors of same type - should find none since there are no other countries
+    # Get neighbors of same type - should find 1 country
     same_type_neighbors = node_db.get_node_neighbors(created_country.uuid, same_type_only=True)
-    assert len(same_type_neighbors) == 0
+    assert len(same_type_neighbors) == 1
+    assert same_type_neighbors[0].name == "Canada"
+
+    # Test rank filtering - lower (should find battles and city)
+    lower_rank_neighbors = node_db.get_node_neighbors(
+        created_country.uuid, same_type_only=False, rank_filter="lower"
+    )
+    assert len(lower_rank_neighbors) == 3
+    neighbor_names = [n.name for n in neighbors]
+    assert "Battle of Midway" in neighbor_names
+    assert "D-Day" in neighbor_names
+    assert "Washington D.C." in neighbor_names
+
+    # Test rank filtering - higher (should find nothing)
+    higher_equal_neighbors = node_db.get_node_neighbors(
+        created_country.uuid, same_type_only=False, rank_filter="higher"
+    )
+    assert len(higher_equal_neighbors) == 0
 
     # Clean up
     node_db.delete_node(created_battle1.uuid)
     node_db.delete_node(created_battle2.uuid)
+    node_db.delete_node(created_city.uuid)
     node_db.delete_node(created_country.uuid)
 
 

--- a/tests/small/test_node_crud.py
+++ b/tests/small/test_node_crud.py
@@ -2,6 +2,8 @@
 
 from datetime import datetime, timedelta
 
+import pytest
+
 from chronicler_backend.db.node import NodeDatabase
 from chronicler_backend.models.node import DateRange, Node, NodeType, RelationshipType
 from chronicler_backend.utils.constants import VECTOR_DIMENSION
@@ -14,7 +16,8 @@ def test_connection(neo4j_db):
     assert result["one"] == 1
 
 
-def test_node_crud_operations(neo4j_db):
+@pytest.mark.asyncio
+async def test_node_crud_operations(neo4j_db):
     """Test basic CRUD operations for nodes."""
     # Create a NodeDatabase instance
     node_db = NodeDatabase(neo4j_db)
@@ -28,7 +31,7 @@ def test_node_crud_operations(neo4j_db):
     )
 
     # Create the node
-    created_node = node_db.create_node(test_node)
+    created_node = await node_db.create_node(test_node)
     assert created_node is not None
     assert created_node.uuid == test_node.uuid
     assert created_node.name == "World War II"
@@ -47,7 +50,7 @@ def test_node_crud_operations(neo4j_db):
 
     # Update the node
     retrieved_node.description = "Updated description for WWII"
-    updated_node = node_db.update_node(retrieved_node)
+    updated_node = await node_db.update_node(retrieved_node)
     assert updated_node is not None
     assert updated_node.description == "Updated description for WWII"
 
@@ -59,7 +62,8 @@ def test_node_crud_operations(neo4j_db):
     assert node_db.get_node(created_node.uuid) is None
 
 
-def test_node_relationships(neo4j_db):
+@pytest.mark.asyncio
+async def test_node_relationships(neo4j_db):
     """Test relationships between nodes."""
     # Create a NodeDatabase instance
     node_db = NodeDatabase(neo4j_db)
@@ -68,10 +72,10 @@ def test_node_relationships(neo4j_db):
     country = Node(
         name="United States", node_type=NodeType.COUNTRY, description="North American nation"
     )
-    created_country = node_db.create_node(country)
+    created_country = await node_db.create_node(country)
 
     country2 = Node(name="Canada", node_type=NodeType.COUNTRY, description="North American nation")
-    created_country2 = node_db.create_node(country2)
+    created_country2 = await node_db.create_node(country2)
 
     # Create two child nodes (battles)
     battle1 = Node(
@@ -80,7 +84,7 @@ def test_node_relationships(neo4j_db):
         description="Naval battle in the Pacific Theater",
         date_range=DateRange(start=datetime(1942, 6, 4), end=datetime(1942, 6, 7)),
     )
-    created_battle1 = node_db.create_node(battle1)
+    created_battle1 = await node_db.create_node(battle1)
 
     battle2 = Node(
         name="D-Day",
@@ -88,7 +92,7 @@ def test_node_relationships(neo4j_db):
         description="Allied invasion of Normandy",
         date_range=DateRange(start=datetime(1944, 6, 6), end=datetime(1944, 6, 6)),
     )
-    created_battle2 = node_db.create_node(battle2)
+    created_battle2 = await node_db.create_node(battle2)
 
     # Create a city node (lower rank than country)
     city = Node(
@@ -96,7 +100,7 @@ def test_node_relationships(neo4j_db):
         node_type=NodeType.CITY,
         description="Capital city of the United States",
     )
-    created_city = node_db.create_node(city)
+    created_city = await node_db.create_node(city)
 
     # Create relationships using the new relationship type enum
     assert node_db.create_relationship(
@@ -168,7 +172,8 @@ def test_node_relationships(neo4j_db):
     node_db.delete_node(created_country.uuid)
 
 
-def test_search_by_date_range(neo4j_db):
+@pytest.mark.asyncio
+async def test_search_by_date_range(neo4j_db):
     """Test searching nodes by date range."""
     node_db = NodeDatabase(neo4j_db)
 
@@ -185,7 +190,7 @@ def test_search_by_date_range(neo4j_db):
             end=now - timedelta(days=3600),  # ~9.9 years ago
         ),
     )
-    node_db.create_node(past_event)
+    await node_db.create_node(past_event)
 
     # Recent event
     recent_event = Node(
@@ -197,7 +202,7 @@ def test_search_by_date_range(neo4j_db):
             end=now - timedelta(days=25),  # 25 days ago
         ),
     )
-    node_db.create_node(recent_event)
+    await node_db.create_node(recent_event)
 
     # Ongoing event
     ongoing_event = Node(
@@ -209,7 +214,7 @@ def test_search_by_date_range(neo4j_db):
             end=now + timedelta(days=10),  # 10 days in future
         ),
     )
-    node_db.create_node(ongoing_event)
+    await node_db.create_node(ongoing_event)
 
     # Future event
     future_event = Node(
@@ -221,7 +226,7 @@ def test_search_by_date_range(neo4j_db):
             end=now + timedelta(days=40),  # 40 days in future
         ),
     )
-    node_db.create_node(future_event)
+    await node_db.create_node(future_event)
 
     try:
         # Search for current events (should find ongoing)
@@ -253,7 +258,8 @@ def test_search_by_date_range(neo4j_db):
             node_db.delete_node(node.uuid)
 
 
-def test_vector_index_and_similarity_search(neo4j_db):
+@pytest.mark.asyncio
+async def test_vector_index_and_similarity_search(neo4j_db):
     """Test vector index setup and similarity search functionality."""
     # Create a NodeDatabase instance
     node_db = NodeDatabase(neo4j_db)
@@ -272,7 +278,7 @@ def test_vector_index_and_similarity_search(neo4j_db):
         vector_embedding=[1.0] * (VECTOR_DIMENSION // 2)
         + [0.0] * (VECTOR_DIMENSION - VECTOR_DIMENSION // 2),
     )
-    created_history = node_db.create_node(history_node)
+    created_history = await node_db.create_node(history_node)
     assert created_history is not None
 
     # Node 2 - Similar to Node 1 (high similarity)
@@ -285,7 +291,7 @@ def test_vector_index_and_similarity_search(neo4j_db):
         vector_embedding=[1.0] * (VECTOR_DIMENSION // 2)
         + [0.1] * (VECTOR_DIMENSION - VECTOR_DIMENSION // 2),
     )
-    created_similar = node_db.create_node(similar_history_node)
+    created_similar = await node_db.create_node(similar_history_node)
     assert created_similar is not None
 
     # Node 3 - Different topic node (low similarity)
@@ -298,7 +304,7 @@ def test_vector_index_and_similarity_search(neo4j_db):
         vector_embedding=[0.0] * (VECTOR_DIMENSION // 2)
         + [1.0] * (VECTOR_DIMENSION - VECTOR_DIMENSION // 2),
     )
-    created_different = node_db.create_node(different_node)
+    created_different = await node_db.create_node(different_node)
     assert created_different is not None
 
     try:


### PR DESCRIPTION
# Summary

This PR implements support for a lightweight sentence transformer model that generates vector embeddings for nodes in our FastAPI/Neo4j application. It enables semantic search capabilities and improves our knowledge graph functionality.

## Key Changes

- **Sentence Transformer Integration**:
  - Added `sentence-transformers[onnx] >= 3.2.0` dependency
  - Implemented the `all-MiniLM-L6-v2` quantized model (384 dimensions instead of 1536)
  - Created a singleton `ModelManager` that works with FastAPI background tasks

- **Node Enhancements**:
  - Added automatic vector embedding generation for nodes from their properties
  - Implemented semantic search GraphQL queries with text-to-vector conversion
  - Added rank-based filtering for node relationships

- **Docker & Infrastructure**:
  - Converted to 2-stage Docker build for efficiency
  - Added persistent volume for model weights in docker-compose.yml
  - Created model download script and entrypoint.sh with environment variable configuration
  - Added Makefile commands for model management

- **Testing**:
  - Added medium-sized tests for vector embeddings and semantic search
  - Implemented GraphQL schema execution tests
  - Added mocks for sentence transformer in small tests

## Documentation

- Updated README with project overview and new architecture details
- Added docstrings throughout new code
- Enhanced GraphQL field descriptions for better API documentation

## Completed Tasks

- [x] Model integration with multi-worker support
- [x] Vector embedding support in Node schema
- [x] Docker and volume configuration
- [x] GraphQL semantic search queries
- [x] FastAPI background task refactoring
- [x] Documentation updates
- [x] Test coverage for all functionality

## (Local) Testing Instructions

1. Run `make docker-restart`
2. Run `make test-all`
3. Dump log results `cat logs/pytest_output.log`

![image](https://github.com/user-attachments/assets/cfb8df5a-2a01-4012-9e3d-0c4ac07ab3a0)
